### PR TITLE
Rename to turbo-frame

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -1,6 +1,6 @@
 # Turbo frame requests are requests made from within a turbo frame with the intention of replacing the content of just
 # that frame, not the whole page. They are automatically tagged as such by the Turbo Frame JavaScript, which adds a
-# <tt>X-Turbolinks-Frame</tt> header to the request. When that header is detected by the controller, we ensure that any
+# <tt>X-Turbo-Frame</tt> header to the request. When that header is detected by the controller, we ensure that any
 # template layout is skipped (since we're only working on an in-page frame, thus can skip the weight of the layout), and
 # that the etag for the page is changed (such that a cache for a layout-less request isn't served on a normal request
 # and vice versa).
@@ -16,7 +16,6 @@ module Turbo::Frames::FrameRequest
 
   private
     def turbo_frame_request?
-      # FIXME: X-Turbolinks-Frame -> X-Turbo-Frame
-      request.headers["X-Turbolinks-Frame"].present?
+      request.headers["X-Turbo-Frame"].present?
     end
 end

--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -5,24 +5,22 @@ module Turbo::FramesHelper
   #
   # === Examples
   #
-  #   # => <turbolinks-frame id="tray" links-target="top" src="http://example.com/trays/1"></turbolinks-frame>
+  #   # => turbo-frame id="tray" links-target="top" src="http://example.com/trays/1"></turbolinks-frame>
   #   <%= turbo_frame_tag "tray", src: tray_path(tray) %>
   #
-  #   # => <turbolinks-frame id="tray" src="http://example.com/trays/1"></turbolinks-frame>
+  #   # => turbo-frame id="tray" src="http://example.com/trays/1"></turbolinks-frame>
   #   <%= turbo_frame_tag "tray", src: tray_path(tray), links_target: false %>
   #
-  #   # => <turbolinks-frame id="tray" links-target="other_tray"></turbolinks-frame>
+  #   # => turbo-frame id="tray" links-target="other_tray"></turbolinks-frame>
   #   <%= turbo_frame_tag "tray", links_target: "other_tray" %>
   #
-  #   # => <turbolinks-frame id="tray"><div>My tray frame!</div></turbolinks-frame>
+  #   # => turbo-frame id="tray"><div>My tray frame!</div></turbolinks-frame>
   #   <%= turbo_frame_tag "tray" do %>
   #     <div>My tray frame!</div>
   #   <% end %>
-  #
-  # FIXME: turbolinks-frame -> turbo-frame
   def turbo_frame_tag(id, src: nil, links_target: nil, **attributes, &block)
     links_target ||= links_target != false && src.present? ? "top" : nil
 
-    tag.turbolinks_frame(**attributes.merge(id: id, src: src, "links-target": links_target).compact, &block)
+    tag.turbo_frame(**attributes.merge(id: id, src: src, "links-target": links_target).compact, &block)
   end
 end

--- a/test/dummy/app/views/trays/show.html.erb
+++ b/test/dummy/app/views/trays/show.html.erb
@@ -1,3 +1,3 @@
-<turbolinks-frame id="tray">
+turbo-frame id="tray">
   <div>This is a tray!</div>
 </turbolinks-frame>

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -5,7 +5,7 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     get tray_path(id: 1)
     assert_select "title", count: 1
 
-    get tray_path(id: 1), headers: { "X-Turbolinks-Frame" => "true" }
+    get tray_path(id: 1), headers: { "X-Turbo-Frame" => "true" }
     assert_select "title", count: 0
   end
 
@@ -13,7 +13,7 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     get tray_path(id: 1)
     etag_without_frame = @response.headers["ETag"]
 
-    get tray_path(id: 1), headers: { "X-Turbolinks-Frame" => "true" }
+    get tray_path(id: 1), headers: { "X-Turbo-Frame" => "true" }
     etag_with_frame = @response.headers["ETag"]
 
     assert_not_equal etag_with_frame, etag_without_frame

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -2,20 +2,20 @@ require "turbo_test"
 
 class Turbo::FramesHelperTest < ActionView::TestCase
   test "links target defaults to top when src is supplied" do
-    assert_dom_equal %(<turbolinks-frame src="/trays/1" links-target="top" id="tray"></turbolinks-frame>), turbo_frame_tag("tray", src: "/trays/1")
+    assert_dom_equal %(<turbo-frame src="/trays/1" links-target="top" id="tray"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1")
   end
 
   test "convert case on links target" do
-    assert_dom_equal %(<turbolinks-frame src="/trays/1" links-target="other_tray" id="tray"></turbolinks-frame>),
+    assert_dom_equal %(<turbo-frame src="/trays/1" links-target="other_tray" id="tray"></turbo-frame>),
       turbo_frame_tag("tray", src: "/trays/1", links_target: "other_tray")
   end
 
   test "opt out of default links target with src" do
-    assert_dom_equal %(<turbolinks-frame src="/trays/1" id="tray"></turbolinks-frame>),
+    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray"></turbo-frame>),
       turbo_frame_tag("tray", src: "/trays/1", links_target: false)
   end
 
   test "block style" do
-    assert_dom_equal(%(<turbolinks-frame id="tray"><p>tray!</p></turbolinks-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
+    assert_dom_equal(%(<turbo-frame id="tray"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
   end
 end


### PR DESCRIPTION
To match HEY now. Looks like I'll need to update the JS references in hotwire-rails too.