### PR TITLE
Fix an error when assets pipeline is not used

### DIFF
--- a/lib/install/turbo.rb
+++ b/lib/install/turbo.rb
@@ -1,8 +1,10 @@
 say "Yield head in application layout for cache helper"
 insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, "\n    <%= yield :head %>", before: /\s*<\/head>/
 
-say "Add Turbo include tags in application layout"
-insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, "\n    <%= turbo_include_tags %>", before: /\s*<\/head>/
+if Rails.application.config.respond_to?(:assets)
+  say "Add Turbo include tags in application layout"
+  insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, "\n    <%= turbo_include_tags %>", before: /\s*<\/head>/
+end
 
 say "Enable redis in bundle"
 uncomment_lines "Gemfile", %(gem 'redis')

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -8,7 +8,9 @@ module Turbo
     config.turbo = ActiveSupport::OrderedOptions.new
 
     initializer "turbo.assets" do
-      Rails.application.config.assets.precompile += %w( turbo )
+      if Rails.application.config.respond_to?(:assets)
+        Rails.application.config.assets.precompile += %w( turbo )
+      end
     end
 
     initializer "turbo.helpers" do


### PR DESCRIPTION
And also skip add "turbo_include_tags"

```shell
/Users/sen/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/railtie/configuration.rb:97:in `method_missing': undefined method `assets' for #<Rails::Application::Configuration:0x00007fa9795f1a20>
Did you mean?  asset_host (NoMethodError)
```