### PR TITLE
doc: Add Torbo.start() to the installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you use Webpacker, it's:
 
    ```js
    import { Turbo, cable } from "@hotwired/turbo-rails"
+   Turbo.start()
    ```
  
 Note, if you were using Turbolinks/Rails UJS in your app previously, you should remove them:


### PR DESCRIPTION
After following the installation guide, I found the counterpart of `Turbolinks.start()` is `Turbo.start()`.

It's better to have it in the guide for clarity.