### PR TITLE
Create Webpacker specific install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,36 +32,20 @@ With this Rails integration, you can create these asynchronous updates directly 
 
 ## Installation
 
-The JavaScript for Turbo can either be run through the asset pipeline, which is included with this gem, or through the package that lives on NPM, through Webpacker. If you use the asset pipeline, installation is as follows:
+The JavaScript for Turbo can either be run through the asset pipeline, which is included with this gem, or through the package that lives on NPM, through Webpacker.
 
 1. Add the `turbo-rails` gem to your Gemfile: `gem 'turbo-rails'`
 2. Run `./bin/bundle install`
 3. Run `./bin/rails turbo:install`
 
-If you use Webpacker, it's:
+`turbo:rails` automatically delegates to the JS pre-processor you use.
+If `webpacker` is configured hooks up through `webpacker`, else uses `asset pipline`.
 
-1. Add the `turbo-rails` gem to your Gemfile: `gem 'turbo-rails'`
-2. Run `./bin/bundle install`
-3. Run `./bin/yarn add @hotwired/turbo-rails`
-4. Add it to your application's JavaScript pack:
+If you are not happy with automatic delegation you can use
+* `turbo:install:webpacker` - for the webpacker
+* `turbo:install:asset_pipeline` - for the asset pipeline
 
-   ```js
-   import { Turbo, cable } from "@hotwired/turbo-rails"
-   ```
- 
-Note, if you were using Turbolinks/Rails UJS in your app previously, you should remove them:
 
-1. Remove the `turbolinks` gem from your Gemfile.
-2. Run `./bin/bundle install`
-3. Run `./bin/yarn remove turbolinks @rails/ujs`
-4. Remove these from your application's JavaScript pack:
-
-   ```js
-   import Rails from "@rails/ujs"
-   import Turbolinks from "turbolinks"
-   Rails.start()
-   Turbolinks.start()
-   ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,7 @@ The JavaScript for Turbo can either be run through the asset pipeline, which is 
 2. Run `./bin/bundle install`
 3. Run `./bin/rails turbo:install`
 
-`turbo:rails` automatically delegates to the JS pre-processor you use.
-If `webpacker` is configured hooks up through `webpacker`, else uses `asset pipline`.
-
-If you are not happy with automatic delegation you can use
-* `turbo:install:webpacker` - for the webpacker
-* `turbo:install:asset_pipeline` - for the asset pipeline
-
+Running `turbo:install` will install through NPM if Webpacker is installed in the application. Otherwise the asset pipeline version is used.
 
 
 ## Usage

--- a/lib/install/turbo_with_asset_pipeline.rb
+++ b/lib/install/turbo_with_asset_pipeline.rb
@@ -17,4 +17,4 @@ uncomment_lines "Gemfile", %(gem 'redis')
 say "Switch development cable to use redis"
 gsub_file "config/cable.yml", /development:\n\s+adapter: async/, "development:\n  adapter: redis\n  url: redis://localhost:6379/1"
 
-say "Turbo successfully installed 🎉 ⚡️", :green
+say "Turbo successfully installed ⚡️", :green

--- a/lib/install/turbo_with_asset_pipeline.rb
+++ b/lib/install/turbo_with_asset_pipeline.rb
@@ -16,3 +16,5 @@ uncomment_lines "Gemfile", %(gem 'redis')
 
 say "Switch development cable to use redis"
 gsub_file "config/cable.yml", /development:\n\s+adapter: async/, "development:\n  adapter: redis\n  url: redis://localhost:6379/1"
+
+say "Turbo successfully installed 🎉 ⚡️", :green

--- a/lib/install/turbo_with_webpacker.rb
+++ b/lib/install/turbo_with_webpacker.rb
@@ -1,25 +1,19 @@
 # Some Rails versions use commonJS(require) others use ESM(import).
 TURBOLINKS_REGEX = /(import .* from "turbolinks".*\n|require\("turbolinks"\).*\n)/.freeze
-RAILS_UJS_REGEX  = /(import .* from "@rails\/ujs".*\n|require\("@rails\/ujs"\).*\n)/.freeze
 
 abort "❌ Webpacker not found. Exiting." unless defined?(Webpacker::Engine)
 
-say "Install @hotwired/turbo-rails"
+say "Install Turbo"
 run "yarn add @hotwired/turbo-rails"
 insert_into_file "#{Webpacker.config.source_entry_path}/application.js",
   "import { Turbo, cable } from \"@hotwired/turbo-rails\"\n", before: TURBOLINKS_REGEX
 
-say "Turn off turbolinks"
+say "Remove Turbolinks"
 gsub_file 'Gemfile', /gem 'turbolinks'.*/, ''
 run "bin/bundle", capture: true
 run "bin/yarn remove turbolinks"
 gsub_file "#{Webpacker.config.source_entry_path}/application.js", TURBOLINKS_REGEX, ''
 gsub_file "#{Webpacker.config.source_entry_path}/application.js", /Turbolinks.start.*\n/, ''
-
-say "Turn off @rails/ujs"
-run "bin/yarn remove @rails/ujs"
-gsub_file "#{Webpacker.config.source_entry_path}/application.js", RAILS_UJS_REGEX, ''
-gsub_file "#{Webpacker.config.source_entry_path}/application.js", /Rails.start.*\n/, ''
 
 say "Enable redis in bundle"
 uncomment_lines "Gemfile", %(gem 'redis')

--- a/lib/install/turbo_with_webpacker.rb
+++ b/lib/install/turbo_with_webpacker.rb
@@ -27,4 +27,4 @@ uncomment_lines "Gemfile", %(gem 'redis')
 say "Switch development cable to use redis"
 gsub_file "config/cable.yml", /development:\n\s+adapter: async/, "development:\n  adapter: redis\n  url: redis://localhost:6379/1"
 
-say "Turbo successfully installed 🎉 ⚡️", :green
+say "Turbo successfully installed ⚡️", :green

--- a/lib/install/turbo_with_webpacker.rb
+++ b/lib/install/turbo_with_webpacker.rb
@@ -1,0 +1,30 @@
+# Some Rails versions use commonJS(require) others use ESM(import).
+TURBOLINKS_REGEX = /(import .* from "turbolinks".*\n|require\("turbolinks"\).*\n)/.freeze
+RAILS_UJS_REGEX  = /(import .* from "@rails\/ujs".*\n|require\("@rails\/ujs"\).*\n)/.freeze
+
+abort "❌ Webpacker not found. Exiting." unless defined?(Webpacker::Engine)
+
+say "Install @hotwired/turbo-rails"
+run "yarn add @hotwired/turbo-rails"
+insert_into_file "#{Webpacker.config.source_entry_path}/application.js",
+  "import { Turbo, cable } from \"@hotwired/turbo-rails\"\n", before: TURBOLINKS_REGEX
+
+say "Turn off turbolinks"
+gsub_file 'Gemfile', /gem 'turbolinks'.*/, ''
+run "bin/bundle", capture: true
+run "bin/yarn remove turbolinks"
+gsub_file "#{Webpacker.config.source_entry_path}/application.js", TURBOLINKS_REGEX, ''
+gsub_file "#{Webpacker.config.source_entry_path}/application.js", /Turbolinks.start.*\n/, ''
+
+say "Turn off @rails/ujs"
+run "bin/yarn remove @rails/ujs"
+gsub_file "#{Webpacker.config.source_entry_path}/application.js", RAILS_UJS_REGEX, ''
+gsub_file "#{Webpacker.config.source_entry_path}/application.js", /Rails.start.*\n/, ''
+
+say "Enable redis in bundle"
+uncomment_lines "Gemfile", %(gem 'redis')
+
+say "Switch development cable to use redis"
+gsub_file "config/cable.yml", /development:\n\s+adapter: async/, "development:\n  adapter: redis\n  url: redis://localhost:6379/1"
+
+say "Turbo successfully installed 🎉 ⚡️", :green

--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -1,3 +1,5 @@
+def run_install_template(path) system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}" end
+
 namespace :turbo do
   desc "Install Turbo into the app"
   task :install do
@@ -11,12 +13,12 @@ namespace :turbo do
   namespace :install do
     desc "Install Turbo into the app with asset pipeline"
     task :asset_pipeline do
-      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/turbo_with_asset_pipeline.rb", __dir__)}"
+      run_install_template "turbo_with_asset_pipeline"
     end
 
     desc "Install Turbo into the app with webpacker"
     task :webpacker do
-      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/turbo_with_webpacker.rb", __dir__)}"
+      run_install_template "turbo_with_webpacker"
     end
   end
 end

--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -1,5 +1,5 @@
 namespace :turbo do
-  desc "Install Turbo into the app. If webpacker is configured delegates to the webpacker, else uses asset pipeline"
+  desc "Install Turbo into the app"
   task :install do
     if defined?(Webpacker::Engine)
       Rake::Task["turbo:install:webpacker"].invoke

--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -1,6 +1,22 @@
 namespace :turbo do
-  desc "Install Turbo into the app"
+  desc "Install Turbo into the app. If webpacker is configured delegates to the webpacker, else uses asset pipeline"
   task :install do
-    system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/turbo.rb", __dir__)}"
+    if defined?(Webpacker::Engine)
+      Rake::Task["turbo:install:webpacker"].invoke
+    else
+      Rake::Task["turbo:install:asset_pipeline"].invoke
+    end
+  end
+
+  namespace :install do
+    desc "Install Turbo into the app with asset pipeline"
+    task :asset_pipeline do
+      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/turbo_with_asset_pipeline.rb", __dir__)}"
+    end
+
+    desc "Install Turbo into the app with webpacker"
+    task :webpacker do
+      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/turbo_with_webpacker.rb", __dir__)}"
+    end
   end
 end


### PR DESCRIPTION
Introduce 3 new rake tasks:

* `turbo:install` delegates to webpacker if it is active, else uses asset
pipeline.
* `turbo:install:webpacker` hooks up webpacker
* `turbo:install:asset_pipeline` hooks up asset pipeline

references #19 