### PR TITLE
Make turbo_frame_tag accept model argument

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -7,6 +7,9 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag "tray", src: tray_path(tray) %>
   #   # => <turbo-frame id="tray" src="http://example.com/trays/1"></turbo-frame>
   #
+  #   <%= turbo_frame_tag tray, src: tray_path(tray) %>
+  #   # => <turbo-frame id="tray_1" src="http://example.com/trays/1"></turbo-frame>
+  #
   #   <%= turbo_frame_tag "tray", src: tray_path(tray), links_target: "top" %>
   #   # => <turbo-frame id="tray" links-target="top" src="http://example.com/trays/1"></turbo-frame>
   #
@@ -18,6 +21,8 @@ module Turbo::FramesHelper
   #   <% end %>
   #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
   def turbo_frame_tag(id, src: nil, target: nil, **attributes, &block)
+    id = id.respond_to?(:to_key) ? dom_id(id) : id
+
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)
   end
 end

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -9,6 +9,12 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" target="_top"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", target: "_top")
   end
 
+  test "frame with model argument" do
+    record = Message.new(record_id: "1", content: "ignored")
+
+    assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
+  end
+
   test "block style" do
     assert_dom_equal(%(<turbo-frame id="tray"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
   end


### PR DESCRIPTION
When passed a "model" (i.e. an instance that responds to `#to_key`),
transform it into a String `id` by passing it to [dom_id][]. If not,
pass the value along unmodified.

[dom_id]: https://edgeapi.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id