### PR TITLE
Mixin ActionView::RecordIdentifier#dom_id

### DIFF
--- a/app/controllers/turbo/streams/turbo_streams_tag_builder.rb
+++ b/app/controllers/turbo/streams/turbo_streams_tag_builder.rb
@@ -16,6 +16,8 @@
 module Turbo::Streams::TurboStreamsTagBuilder
   private
 
+  delegate :dom_id, to: ActionView::RecordIdentifier
+
   def turbo_stream
     Turbo::Streams::TagBuilder.new(view_context)
   end


### PR DESCRIPTION
When the `Turbo::Streams::TurboStreamsTagBuilder` module is mixed-into a
Controller, also mix in the [ActionView::RecordIdentifier#dom_id][dom_id].

[dom_id]: https://edgeapi.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id