### PR TITLE
Document how to use turbo-rails with native adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ The JavaScript for Turbo can either be run through the asset pipeline, which is 
 
 Running `turbo:install` will install through NPM if Webpacker is installed in the application. Otherwise the asset pipeline version is used.
 
-If you're using Webpack and need to use either the cable consumer or the Turbo instance, you can import [`Turbo`](https://turbo.hotwire.dev/reference/drive) and/or [`cable`](https://github.com/hotwired/turbo-rails/blob/87542edecc4008c46249e5d8ede79b3eda62a5e2/app/javascript/turbo/cable.js) (`import { Turbo, cable } from "@hotwired/turbo-rails"`), but ensure that your application actually *uses* the members it `import`s when using this style (see [turbo-rails#48](https://github.com/hotwired/turbo-rails/issues/48)).
+If you're using Webpack and need to use either the cable consumer or the Turbo instance, you can import [`Turbo`](https://turbo.hotwire.dev/reference/drive) and/or [`cable`](https://github.com/hotwired/turbo-rails/blob/main/app/javascript/turbo/cable.js) (`import { Turbo, cable } from "@hotwired/turbo-rails"`), but ensure that your application actually *uses* the members it `import`s when using this style (see [turbo-rails#48](https://github.com/hotwired/turbo-rails/issues/48)).
 
+If you're using a [native adapter](https://turbo.hotwire.dev/handbook/native), you'll need to assign `window.Turbo`, even if it's not used for anything else:
+
+```js
+import { Turbo } from "@hotwired/turbo-rails"
+window.Turbo = Turbo
+```
 
 ## Usage
 


### PR DESCRIPTION
The [Android](https://github.com/hotwired/turbo-android/blob/8fb001a4d20bbb0517e554fa4ba18c1969f5722d/turbo/src/main/assets/js/turbo_bridge.js#L10) and [iOS](https://github.com/hotwired/turbo-ios/blob/210f83a115e2deb113564b0d31bca0ed3aeddede/Source/WebView/turbo.js#L11) adapters both require `window.Turbo`.

If you just do `import "@hotwired/turbo-rails"` nothing is set on the `window` (this is a change from Turbolinks). So you need to set it manually if you want to use a native adapter. This PR adds a note explaining this to the docs.

(For the record, I think it would be better to just assign `window.Turbo` always - it would also simplify the current instructions around when you should/shouldn't import the `Turbo` instance. Happy to look into a PR for that as an alternative.)