### PR TITLE
Fix: Erb typo

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -14,7 +14,7 @@
 #   <%= turbo_stream.append "entries" do %>
 #     <% # format is automatically switched, such that _entry.html.erb partial is rendered, not _entry.turbo_stream.erb %>
 #     <%= render partial: "entries/entry", locals: { entry: entry } %>
-#   <%= end %>
+#   <% end %>
 #
 # Or you can render the HTML that should be part of the update inline:
 #


### PR DESCRIPTION
Fixes, small typo on the `TagBuilder` docs.