### PR TITLE
Update tag_builder.rb - Fixes #102

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -122,7 +122,7 @@ class Turbo::Streams::TagBuilder
     def render_record(possible_record)
       if possible_record.respond_to?(:to_partial_path)
         record = possible_record
-        @view_context.render(partial: record.to_partial_path, locals: { record.model_name.param_key.to_sym => record }, formats: [ :html ])
+        @view_context.render(partial: record.to_partial_path, object: record, formats: :html)
       end
     end
 end

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -122,7 +122,7 @@ class Turbo::Streams::TagBuilder
     def render_record(possible_record)
       if possible_record.respond_to?(:to_partial_path)
         record = possible_record
-        @view_context.render(partial: record.to_partial_path, locals: { record.model_name.singular.to_sym => record }, formats: [ :html ])
+        @view_context.render(partial: record.to_partial_path, locals: { record.model_name.param_key.to_sym => record }, formats: [ :html ])
       end
     end
 end

--- a/test/dummy/app/controllers/users/profiles_controller.rb
+++ b/test/dummy/app/controllers/users/profiles_controller.rb
@@ -1,0 +1,9 @@
+module Users
+  class ProfilesController < ApplicationController
+    
+    def show
+      @profile = Users::Profile.new(record_id: 1, name: "User")
+    end
+    
+  end
+end

--- a/test/dummy/app/models/users/profile.rb
+++ b/test/dummy/app/models/users/profile.rb
@@ -1,0 +1,25 @@
+module Users
+  class Profile
+    attr_reader :record_id, :name
+  
+    def self.model_name
+      ActiveModel::Name.new(self)
+    end
+  
+    def initialize(record_id:, name:)
+      @record_id, @name = record_id, name
+    end
+  
+    def to_key
+      [ record_id ]
+    end
+  
+    def to_partial_path
+      "users/profiles/profile"
+    end
+  
+    def model_name
+      self.class.model_name
+    end
+  end
+end

--- a/test/dummy/app/views/users/profiles/_profile.html.erb
+++ b/test/dummy/app/views/users/profiles/_profile.html.erb
@@ -1,0 +1,1 @@
+<p><%= profile.name %></p>

--- a/test/dummy/app/views/users/profiles/show.turbo_stream.erb
+++ b/test/dummy/app/views/users/profiles/show.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace @profile %>
+<%= turbo_stream.update @profile %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   resources :messages
   resources :trays
   resources :posts
+  namespace :users do
+    resources :profiles
+  end
 end

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -37,4 +37,12 @@ STREAM
 STREAM
     end
   end
+  
+  test "render correct partial for namespaced models" do
+    get users_profile_path(id: 1), as: :turbo_stream
+    assert_equal <<-STREAM, @response.body
+<turbo-stream action="replace" target="users_profile_1"><template><p>User</p></template></turbo-stream>
+<turbo-stream action="update" target="users_profile_1"><template><p>User</p></template></turbo-stream>
+STREAM
+  end
 end

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -40,9 +40,9 @@ STREAM
   
   test "render correct partial for namespaced models" do
     get users_profile_path(id: 1), as: :turbo_stream
-    assert_equal <<-STREAM, @response.body
+    assert_dom_equal <<~HTML, @response.body
 <turbo-stream action="replace" target="users_profile_1"><template><p>User</p></template></turbo-stream>
 <turbo-stream action="update" target="users_profile_1"><template><p>User</p></template></turbo-stream>
-STREAM
+    HTML
   end
 end


### PR DESCRIPTION
When using a model from an engine (using isolated_namespace), `singular` returns the model name prefixed with `myengine_`. This results in the wrong local variable. `param_key` returns the correct key without the engine prefix.