### PR TITLE
Renames install method in turbo_tasks.rake to avoid conflict if tailwindcss-rails is also installed

### DIFF
--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -1,4 +1,4 @@
-def run_install_template(path) system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}" end
+def run_turbo_install_template(path) system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}" end
 
 namespace :turbo do
   desc "Install Turbo into the app"
@@ -13,12 +13,12 @@ namespace :turbo do
   namespace :install do
     desc "Install Turbo into the app with asset pipeline"
     task :asset_pipeline do
-      run_install_template "turbo_with_asset_pipeline"
+      run_turbo_install_template "turbo_with_asset_pipeline"
     end
 
     desc "Install Turbo into the app with webpacker"
     task :webpacker do
-      run_install_template "turbo_with_webpacker"
+      run_turbo_install_template "turbo_with_webpacker"
     end
   end
 end


### PR DESCRIPTION
Both this gem and `tailwindcss-rails` use the same method name in the install task, `run_install_template`

https://github.com/rails/tailwindcss-rails/blob/e21140c382fbb1f3c31a3fad37c06d4768d63496/lib/tasks/tailwindcss_tasks.rake#L34

Having both gems installed, running `rails turbo:install` fails because it runs the `tailwindcss-rails` method.

Error message below (paths shortened):

```
→ rails turbo:install
rails aborted!
Thor::Error: Could not find "/Users/andres/.../gems/tailwindcss-rails-0.3.1/lib/install/turbo_with_webpacker.rb" in any of your source paths. Your current source paths are: 
/Users/andres/.../gems/railties-6.1.1/lib/rails/generators/rails/app/templates

Tasks: TOP => app:template
```

I've renamed the install method here, following the naming used in the `stimulus-rails` gem. Renaming it in the `tailwindcss-rails` gem solves the issue too.