### PR TITLE
Support for Unobtrusive JavaScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,11 @@ gemspec
 
 gem 'rake'
 gem 'byebug'
+
+group :test do
+  gem 'capybara'
+  gem 'rexml'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
+  gem 'webrick'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,8 +66,19 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
     byebug (11.0.1)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.10.0)
@@ -91,6 +102,7 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -122,6 +134,12 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rake (13.0.0)
+    regexp_parser (1.8.2)
+    rexml (3.2.4)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -132,9 +150,16 @@ GEM
     thor (1.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    webdrivers (4.5.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
+    webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -142,8 +167,13 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  capybara
   rake
+  rexml
+  selenium-webdriver
   turbo-rails!
+  webdrivers
+  webrick
 
 BUNDLED WITH
    2.2.3

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,7 @@
+require "turbo_test"
+
+Capybara.server = :webrick
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+end

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -3,7 +3,13 @@ class MessagesController < ApplicationController
     @message = Message.new(record_id: 1, content: "My message")
   end
 
+  def new
+    sleep params[:sleep].to_i
+  end
+
   def create
+    sleep params[:sleep].to_i
+
     respond_to do |format|
       format.html { redirect_to message_url(id: 1) }
       format.turbo_stream { render turbo_stream: turbo_stream.append(:messages, "message_1") }

--- a/test/dummy/app/views/messages/new.html.erb
+++ b/test/dummy/app/views/messages/new.html.erb
@@ -1,0 +1,22 @@
+<%= content_for :head do %>
+  <script type="module">
+    import Rails from "https://cdn.skypack.dev/@rails/ujs"
+
+    const { delegate, disableElement, enableElement } = Rails
+
+    delegate(document, Rails.linkDisableSelector,   "turbo:before-cache", enableElement)
+    delegate(document, Rails.buttonDisableSelector, "turbo:before-cache", enableElement)
+    delegate(document, Rails.buttonDisableSelector, "turbo:submit-end", enableElement)
+
+    delegate(document, Rails.formSubmitSelector, "turbo:submit-start", disableElement)
+    delegate(document, Rails.formSubmitSelector, "turbo:submit-end", enableElement)
+    delegate(document, Rails.formSubmitSelector, "turbo:before-cache", enableElement)
+  </script>
+<% end %>
+
+<a href="<%= new_message_path(sleep: 2) %>" data-remote="true" data-disable-with="Reloading">Reload</a>
+
+<%= form_with url: messages_path(sleep: 2), data: { remote: true } do %>
+  <button data-disable-with="Submitting">Submit</button>
+  <button data-confirm="Are you sure?">Confirm</button>
+<% end %>

--- a/test/system/rails_ujs_test.rb
+++ b/test/system/rails_ujs_test.rb
@@ -1,0 +1,11 @@
+require "application_system_test_case"
+
+class RailsUjsTest < ApplicationSystemTestCase
+  test "data-disable-with integration" do
+    visit new_message_path
+
+    click_on("Reload").then { assert_link "Reloading" }
+    click_on("Submit").then { assert_button "Submitting", disabled: true }
+    accept_confirm          { click_on("Confirm") }
+  end
+end


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo-rails/issues/33.
Closes https://github.com/hotwired/turbo-rails/issues/37.

---

Re-create [hotwired/turbo#40][].

When loaded alongside [@rails/ujs][], start it via `Rails.start()`, and
then declare the [`turbo:`-prefixed events][turbo-events] that
correspond to their `ajax:`-prefixed counterparts.

Test suite changes
---

First, introduce System Test coverage to drive the Turbo and Rails
integration through a headless browser.

Next, change some dummy controller actions to accept a `?sleep=` query
parameter to delay their responses long enough to ensure that
`data-disabled-with` and `data-confirm` have a wide enough window of
opportunity for test coverage to exercise their behaviors.

[hotwired/turbo#40]: https://github.com/hotwired/turbo/pull/40
[@rails/ujs]: https://github.com/rails/rails/tree/v6.1.0/actionview/app/assets/javascripts
[turbo-events]: https://turbo.hotwire.dev/reference/events