### PR TITLE
Loosen Action Cable NPM package version constraint to allow 6.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@hotwired/turbo": "^7.0.0-beta.4",
-    "@rails/actioncable": "^6.1.0"
+    "@rails/actioncable": "^6.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^11.0.1",


### PR DESCRIPTION
This is my first PR to turbo-rails, so let me know if I did anything wrong!

The [`gemspec`](https://github.com/hotwired/turbo-rails/blob/20070ca30768c5b88e9f317606bf2cd08ed8eb78/turbo-rails.gemspec#L13) allows Rails 6.0.x, so letting them match up on the NPM side is great:

https://github.com/hotwired/turbo-rails/blob/20070ca30768c5b88e9f317606bf2cd08ed8eb78/turbo-rails.gemspec#L13

There should be no breaking changes between Action Cable 6.0.x and 6.1.x that would stop this from working.

Closes #95.