### PR TITLE
Improve implicit view path handling in streams tag builder

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -122,7 +122,7 @@ class Turbo::Streams::TagBuilder
     def render_record(possible_record)
       if possible_record.respond_to?(:to_partial_path)
         record = possible_record
-        @view_context.render(partial: record.to_partial_path, object: record, formats: :html)
+        @view_context.render(partial: record, formats: :html)
       end
     end
 end

--- a/test/dummy/app/controllers/admin/base_controller.rb
+++ b/test/dummy/app/controllers/admin/base_controller.rb
@@ -1,0 +1,3 @@
+class Admin::BaseController < ApplicationController
+  prepend_view_path 'app/views/admin'
+end

--- a/test/dummy/app/controllers/admin/companies_controller.rb
+++ b/test/dummy/app/controllers/admin/companies_controller.rb
@@ -1,0 +1,5 @@
+class Admin::CompaniesController < Admin::BaseController
+  def show
+    @company = Company.new(id: 1, name: "Basecamp")
+  end
+end

--- a/test/dummy/app/models/company.rb
+++ b/test/dummy/app/models/company.rb
@@ -1,0 +1,9 @@
+class Company
+  include ActiveModel::Model
+
+  attr_accessor :id, :name
+
+  def to_partial_path
+    "companies/company"
+  end
+end

--- a/test/dummy/app/views/admin/companies/_company.html.erb
+++ b/test/dummy/app/views/admin/companies/_company.html.erb
@@ -1,0 +1,2 @@
+<p><%= t '.name' %></p>
+<p><%= company.name %></p>

--- a/test/dummy/app/views/admin/companies/show.turbo_stream.erb
+++ b/test/dummy/app/views/admin/companies/show.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace @company %>

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -31,3 +31,7 @@
 
 en:
   hello: "Hello world"
+  admin:
+    companies:
+      company:
+        name: "Company:"

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
   namespace :users do
     resources :profiles
   end
+  namespace :admin do
+    resources :companies
+  end
 end

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -43,4 +43,12 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
       <turbo-stream action="update" target="users_profile_1"><template><p>David</p></template></turbo-stream>
     HTML
   end
+
+  test "render correct partial and I18n with a custom view path in the controller" do
+    get admin_company_path(id: 1), as: :turbo_stream
+    assert_dom_equal <<~HTML, @response.body.remove(/\n(?=<\/)/)
+      <turbo-stream action="replace" target="company_1"><template><p>Company:</p>
+      <p>Basecamp</p></template></turbo-stream>
+    HTML
+  end
 end


### PR DESCRIPTION
If you are in a controller that has added something to the view path, like this:

```ruby
class Admin::BaseController < ApplicationController
  prepend_view_path 'app/views/admin'
end

class Admin::CompaniesController < Admin::BaseController
  def show
  end
end
```

The default rendering within `Streams::TagBuilder` does not do the right partial path lookup within the view path, due to it explicitly passing `partial: record.to_partial_path` to `render`. It also happens to cause some interesting I18n lookup issues, due to the incorrect virtual path.

By passing `record` itself, we get to take advantage of Action View's built-in partial path generation and virtual path logic, which accounts for any custom view paths.

It also happens to be even simpler to implement!

This is essentially an extension of the work already done in #90.