### PR TITLE
Add System Test coverage for broadcasting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,11 @@ gemspec
 
 gem 'rake'
 gem 'byebug'
+gem 'puma'
+
+group :test do
+  gem 'capybara'
+  gem 'rexml'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,8 +66,19 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
     byebug (11.0.1)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
@@ -91,6 +102,9 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    public_suffix (4.0.6)
+    puma (5.2.0)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -122,6 +136,12 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rake (13.0.0)
+    regexp_parser (1.8.2)
+    rexml (3.2.4)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -132,9 +152,15 @@ GEM
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    webdrivers (4.5.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -142,8 +168,13 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  capybara
+  puma
   rake
+  rexml
+  selenium-webdriver
   turbo-rails!
+  webdrivers
 
 BUNDLED WITH
    2.2.3

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,9 @@
+require "turbo_test"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+end
+
+Capybara.configure do |config|
+  config.server = :puma, { Silent: true }
+end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= yield :head %>
+    <%= javascript_include_tag "turbo", type: "module" %>
   </head>
 
   <body>

--- a/test/dummy/app/views/messages/index.html.erb
+++ b/test/dummy/app/views/messages/index.html.erb
@@ -1,0 +1,4 @@
+<h1>Messages</h1>
+
+<%= turbo_stream_from "messages" %>
+<div id="messages"></div>

--- a/test/dummy/app/views/users/profiles/index.html.erb
+++ b/test/dummy/app/views/users/profiles/index.html.erb
@@ -1,0 +1,4 @@
+<h1>Users::Profiles</h1>
+
+<%= turbo_stream_from "users_profiles" %>
+<div id="users_profiles"></div>

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -1,0 +1,29 @@
+require "application_system_test_case"
+
+class BroadcastsTest < ApplicationSystemTestCase
+  test "Message broadcasts Turbo Streams" do
+    visit messages_path
+
+    assert_text "Messages"
+    assert_appends_text "Message 1" do |text|
+      Message.new(record_id: 1, content: text).broadcast_append_to(:messages)
+    end
+  end
+
+  test "Users::Profile broadcasts Turbo Streams" do
+    visit users_profiles_path
+
+    assert_text "Users::Profiles"
+    assert_appends_text "Profile 1" do |text|
+      Users::Profile.new(id: 1, name: text).broadcast_append_to(:users_profiles)
+    end
+  end
+
+  private
+
+    def assert_appends_text(text, &block)
+      assert_no_text text
+      perform_enqueued_jobs { block.call(text) }
+      assert_text text
+    end
+end

--- a/test/turbo_test.rb
+++ b/test/turbo_test.rb
@@ -8,3 +8,7 @@ require "byebug"
 require_relative "dummy/config/environment"
 
 ActionCable.server.config.logger = Logger.new(STDOUT) if ENV["VERBOSE"]
+
+class ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+end


### PR DESCRIPTION
Introduce System Test coverage to drive the Turbo and Rails integration
through a headless browser.

Turbo Stream broadcasting relies on both server-side behavior and
client-side behavior. ActionDispatch::Integration tests are useful for
covering particular edge cases, but in-browser System Tests enable tests
to exercise the entire spectrum.