### PR TITLE
fix namescaped model naming when broadcast to partial

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -233,7 +233,7 @@ module Turbo::Broadcastable
 
     def broadcast_rendering_with_defaults(options)
       options.tap do |o|
-        o[:locals]    = (o[:locals] || {}).reverse_merge!(model_name.singular.to_sym => self)
+        o[:object] ||= self
         o[:partial] ||= to_partial_path
       end
     end

--- a/test/dummy/app/models/users/profile.rb
+++ b/test/dummy/app/models/users/profile.rb
@@ -1,8 +1,13 @@
 module Users
   class Profile
     include ActiveModel::Model
+    include Turbo::Broadcastable
 
     attr_accessor :id, :name
+
+    def to_param
+      "users:profile:#{id}"
+    end
 
     def to_partial_path
       "users/profiles/profile"

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -77,4 +77,11 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
       @message.broadcast_action "prepend"
     end
   end
+
+  test "render correct local name in partial for namespaced models" do
+    @profile = Users::Profile.new(id: 1, name: "Ryan")
+    assert_broadcast_on @profile.to_param, turbo_stream_action_tag("replace", target: "users_profile_1", template: "<p>Ryan</p>\n") do
+      @profile.broadcast_replace
+    end
+  end
 end


### PR DESCRIPTION
Fixes #103. I *think* this should work but would like some other eyes to see if this is the best way to fix it. I modeled it after #90. Once issue is that I'm getting a "\n" in my rendered template and I'm not sure why.

Happy to make any adjustments. Thanks.