### PR TITLE
Extend Assertions to handle Status Codes

### DIFF
--- a/lib/turbo/test_assertions.rb
+++ b/lib/turbo/test_assertions.rb
@@ -7,14 +7,13 @@ module Turbo
       delegate :dom_id, :dom_class, to: ActionView::RecordIdentifier
     end
 
-    def assert_turbo_stream(action:, target: nil, &block)
-      assert_response :ok
+    def assert_turbo_stream(action:, target: nil, status: :ok, &block)
+      assert_response status
       assert_equal Mime[:turbo_stream], response.media_type
       assert_select %(turbo-stream[action="#{action}"][target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]), count: 1, &block
     end
 
     def assert_no_turbo_stream(action:, target: nil)
-      assert_response :ok
       assert_equal Mime[:turbo_stream], response.media_type
       assert_select %(turbo-stream[action="#{action}"][target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]), count: 0
     end

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -6,7 +6,7 @@ class MessagesController < ApplicationController
   def create
     respond_to do |format|
       format.html { redirect_to message_url(id: 1) }
-      format.turbo_stream { render turbo_stream: turbo_stream.append(:messages, "message_1") }
+      format.turbo_stream { render turbo_stream: turbo_stream.append(:messages, "message_1"), status: :created }
     end
   end
 end

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -6,8 +6,8 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to message_path(id: 1)
 
     post messages_path, as: :turbo_stream
-    assert_response :ok
-    assert_turbo_stream action: :append, target: "messages" do |selected|
+    assert_no_turbo_stream action: :update, target: "messages"
+    assert_turbo_stream status: :created, action: :append, target: "messages" do |selected|
       assert_equal "<template>message_1</template>", selected.children.to_html
     end
   end


### PR DESCRIPTION
Follows https://github.com/hotwired/turbo/pull/168

Since Turbo Stream responses can vary from `200 OK`, change the
`assert_turbo_stream` signature to accept a `status:` option (defaulting
to `:ok`).

Since the inverse `assert_no_turbo_stream` is asserting a particular
`action:`, `target:` pairing, omit the `status:` option and remove the
assertions `assert_response :ok` call.