### PR TITLE
call url_for on given src's on turbo_frame tags

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -25,6 +25,7 @@ module Turbo::FramesHelper
   #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
   def turbo_frame_tag(id, src: nil, target: nil, **attributes, &block)
     id = id.respond_to?(:to_key) ? dom_id(id) : id
+    src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)
   end

--- a/test/dummy/app/models/message.rb
+++ b/test/dummy/app/models/message.rb
@@ -16,7 +16,7 @@ class Message
   end
 
   def to_param
-    "message:#{record_id}"
+    record_id.to_s
   end
 
   def to_partial_path
@@ -29,5 +29,13 @@ class Message
 
   def model_name
     self.class.model_name
+  end
+
+  def to_model
+    self
+  end
+
+  def persisted?
+    true
   end
 end

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -5,6 +5,12 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame src="/trays/1" id="tray"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1")
   end
 
+  test "frame with model src" do
+    record = Message.new(record_id: "1", content: "ignored")
+
+    assert_dom_equal %(<turbo-frame src="/messages/1" id="message"></turbo-frame>), turbo_frame_tag("message", src: record)
+  end
+
   test "frame with src and target" do
     assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" target="_top"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", target: "_top")
   end


### PR DESCRIPTION
This uses the url_for method to generate Urls from objects passed into the turbo_frame_tag src attribute.

I've altered the dummy Message #to_param response as I believe it wasn't in line with the real world - but could well have misunderstood that. See link: https://apidock.com/rails/v6.0.0/ActiveModel/Conversion/to_param

Closes #118 
