### PR TITLE
fix(engine): ActionCable should not be a requirement

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -16,6 +16,10 @@ module Turbo
       #{root}/app/jobs
     )
 
+    initializer "turbo.no_action_cable" do
+      Rails.autoloaders.once.do_not_eager_load(Dir["#{root}/app/channels/turbo/*_channel.rb"]) unless defined?(ActionCable)
+    end
+
     initializer "turbo.assets" do
       if Rails.application.config.respond_to?(:assets)
         Rails.application.config.assets.precompile += %w( turbo )


### PR DESCRIPTION
`ActionCable` should not be a requirement to use `turbo-rails`. Not all applications require `rails/all` on `config/application.rb`. Otherwise an exception will be triggered: 

> /gems/2.6.0/gems/turbo-rails-0.5.9/app/channels/turbo/streams_channel.rb:7:in main: uninitialized constant ActionCable (NameError)
Did you mean?  ActionMailer
