### PR TITLE
Webpacker install: Allow require("@rails/activestorage")

### DIFF
--- a/lib/install/turbo_with_webpacker.rb
+++ b/lib/install/turbo_with_webpacker.rb
@@ -1,11 +1,12 @@
 # Some Rails versions use commonJS(require) others use ESM(import).
 TURBOLINKS_REGEX = /(import .* from "turbolinks".*\n|require\("turbolinks"\).*\n)/.freeze
+ACTIVE_STORAGE_REGEX = /(import.*ActiveStorage|require.*@rails\/activestorage.*)/.freeze
 
 abort "❌ Webpacker not found. Exiting." unless defined?(Webpacker::Engine)
 
 say "Install Turbo"
 run "yarn add @hotwired/turbo-rails"
-insert_into_file "#{Webpacker.config.source_entry_path}/application.js", "import \"@hotwired/turbo-rails\"\n", before: /import.*ActiveStorage/
+insert_into_file "#{Webpacker.config.source_entry_path}/application.js", "import \"@hotwired/turbo-rails\"\n", before: ACTIVE_STORAGE_REGEX
 
 say "Remove Turbolinks"
 gsub_file 'Gemfile', /gem 'turbolinks'.*/, ''


### PR DESCRIPTION
Changes the webpacker install to find either `import ActiveStorage` or `require("@rails/activestorage")`

`require("@rails/activestorage")` must have been the Rails default at some point, since I had it in my repo since the initial commit.