### PR TITLE
Run turbo.helpers before config/initializers

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -22,7 +22,7 @@ module Turbo
       end
     end
 
-    initializer "turbo.helpers" do
+    initializer "turbo.helpers", before: :load_config_initializers do
       ActiveSupport.on_load(:action_controller_base) do
         include Turbo::Streams::TurboStreamsTagBuilder, Turbo::Frames::FrameRequest, Turbo::Native::Navigation
         helper Turbo::Engine.helpers

--- a/test/dummy/config/initializers/inspect_helpers.rb
+++ b/test/dummy/config/initializers/inspect_helpers.rb
@@ -1,0 +1,4 @@
+ActionController::Base.class_eval do
+  $dummy_ac_base_ancestors_in_initializers = ancestors
+  $dummy_ac_base_helpers_in_initializers = _helpers.ancestors
+end

--- a/test/initializers/helpers_test.rb
+++ b/test/initializers/helpers_test.rb
@@ -1,0 +1,8 @@
+require "turbo_test"
+
+class Turbo::HelpersInInitializersTest < ActionDispatch::IntegrationTest
+  test "AC::Base has the helpers in place when initializers run" do
+    assert_includes $dummy_ac_base_ancestors_in_initializers, Turbo::Streams::TurboStreamsTagBuilder
+    assert_includes $dummy_ac_base_helpers_in_initializers, Turbo::StreamsHelper
+  end
+end


### PR DESCRIPTION
## The problem

In theory, the initializer `turbo.helpers` is good as it is, but in Rails < 7 loading a controller during initialization is not an error condition —you get a warning—, and due to an [unfortunate combination of things](https://github.com/hotwired/turbo-rails/issues/64#issuecomment-778601827), that results in missing helpers in production. We've seen projects where the warning is not addressed.

## The proposed solution

There are several ways to address this, from telling users to not ignore the warning and close doing nothing, up to releasing a Rails 6.1._x_ where loading controllers during initialization becomes an error condition.

To me, this patch represents a fine balance: We make helpers available even if users ignore the warning just with a minimal tweak on initializers ordering. As I said, in theory this is not needed, but I believe it is fine to trade a bit of purity with pragmatism in this case.

## Patch notes

I did not see a natural place for adding coverage, so created a new directory. Please let me know if you'd prefer to have the test in a different place.

The dummy initializer uses `ActionController::Base.class_eval` because I want to be certain (and communicate to the reader) that we are reopening the class, not defining it. Please let me also know if you'd like to do this in a different way.

Fixes #64.