### PR TITLE
Introduce disableDriveByDefault method to allow users to disable Drive by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ During rendering, Turbo replaces the current `<body>` element outright and merge
 
 Whereas Turbolinks previously just dealt with links, Turbo can now also process form submissions and responses. This means the entire flow in the web application is wrapped into Turbo, making all the parts fast. No more need for `data-remote=true`.
 
+Turbo Drive can be disabled on a per-element basis by annotating the element or any of its ancestors with `data-turbo="false"`. If you want Turbo Drive to be disabled by default, then you can adjust your import like this:
+
+```js
+import { Turbo } from "@hotwired/turbo-rails"
+Turbo.disableDriveByDefault()
+```
+
+Then you can use `data-turbo="true"` to enable Drive on a per-element basis.
+
 
 ## Turbo Frames
 

--- a/app/assets/javascripts/turbo.js
+++ b/app/assets/javascripts/turbo.js
@@ -2586,6 +2586,7 @@ class Session {
     this.enabled = true;
     this.progressBarDelay = 500;
     this.started = false;
+    this.disableDriveByDefault = false;
   }
   start() {
     if (!this.started) {
@@ -2772,9 +2773,12 @@ class Session {
   elementIsNavigable(element) {
     const container = element === null || element === void 0 ? void 0 : element.closest("[data-turbo]");
     if (container) {
+      if (this.disableDriveByDefault) {
+        return container.getAttribute("data-turbo") == "true";
+      }
       return container.getAttribute("data-turbo") != "false";
     } else {
-      return true;
+      return !this.disableDriveByDefault;
     }
   }
   locationIsVisitable(location) {
@@ -2831,6 +2835,10 @@ function clearCache() {
 
 function setProgressBarDelay(delay) {
   session.setProgressBarDelay(delay);
+}
+
+function disableDriveByDefault() {
+  session.disableDriveByDefault = true;
 }
 
 start();


### PR DESCRIPTION
It can then be enabled on a per-element basis with `data-turbo="true"`. I also added some documentation to the README.md.

Usage is provided in the edit of README.

Fixes #139