### PR TITLE
Discard broadcast jobs on deserialization error

### DIFF
--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -1,5 +1,7 @@
 # The job that powers all the <tt>broadcast_$action_later</tt> broadcasts available in <tt>Turbo::Streams::Broadcasts</tt>.
 class Turbo::Streams::ActionBroadcastJob < ActiveJob::Base
+  discard_on ActiveJob::DeserializationError
+  
   def perform(stream, action:, target:, **rendering)
     Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target, **rendering
   end

--- a/app/jobs/turbo/streams/broadcast_job.rb
+++ b/app/jobs/turbo/streams/broadcast_job.rb
@@ -1,6 +1,8 @@
 # The job that powers the <tt>broadcast_render_later_to</tt> available in <tt>Turbo::Streams::Broadcasts</tt> for rendering
 # turbo stream templates.
 class Turbo::Streams::BroadcastJob < ActiveJob::Base
+  discard_on ActiveJob::DeserializationError
+  
   def perform(stream, **rendering)
     Turbo::StreamsChannel.broadcast_render_to stream, **rendering
   end


### PR DESCRIPTION
`Turbo::Streams::ActionBroadcastJob` and `Turbo::Streams::BroadcastJob` can fail if they reference AR records that are deleted after the job has been enqueued but before it has run.

In this case it probably makes sense to discard the job rather than retrying it indefinitely.