### PR TITLE
[RFC] Add remove_if_present to append and prepend (avoids double-insert)

### DIFF
--- a/app/assets/javascripts/turbo.js
+++ b/app/assets/javascripts/turbo.js
@@ -1191,11 +1191,21 @@ function activateElement(element) {
 const StreamActions = {
   append() {
     var _a;
-    (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.append(this.templateContent);
+    if (!this.replaceIfPresent || ((_a = this.replaceIfPresentElement) === null || _a === void 0)) {
+      (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.append(this.templateContent);
+    }
+    else {
+      _a.replaceWith(this.templateContent)
+    }
   },
   prepend() {
     var _a;
-    (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.prepend(this.templateContent);
+    if (!this.replaceIfPresent || ((_a = this.replaceIfPresentElement) === null || _a === void 0)) {
+      (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.prepend(this.templateContent);
+    }
+    else {
+      _a.replaceWith(this.templateContent)
+    }
   },
   remove() {
     var _a;
@@ -1254,6 +1264,13 @@ class StreamElement extends HTMLElement {
     }
     this.raise("target attribute is missing");
   }
+  get replaceIfPresentElement(){
+    var _a;
+    if (this.replaceIfPresent) {
+      return (_a = this.ownerDocument) === null || _a === void 0 ? void 0 : _a.getElementById(this.replaceIfPresent);
+    }
+    this.raise("target attribute is missing");
+  }
   get templateContent() {
     return this.templateElement.content;
   }
@@ -1268,6 +1285,9 @@ class StreamElement extends HTMLElement {
   }
   get target() {
     return this.getAttribute("target");
+  }
+  get replaceIfPresent(){
+    return this.getAttribute("replace_if_present");
   }
   raise(message) {
     throw new Error(`${this.description}: ${message}`);

--- a/app/assets/javascripts/turbo.js
+++ b/app/assets/javascripts/turbo.js
@@ -1191,21 +1191,11 @@ function activateElement(element) {
 const StreamActions = {
   append() {
     var _a;
-    if (!this.replaceIfPresent || ((_a = this.replaceIfPresentElement) === null || _a === void 0)) {
-      (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.append(this.templateContent);
-    }
-    else {
-      _a.replaceWith(this.templateContent)
-    }
+    (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.append(this.templateContent);
   },
   prepend() {
     var _a;
-    if (!this.replaceIfPresent || ((_a = this.replaceIfPresentElement) === null || _a === void 0)) {
-      (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.prepend(this.templateContent);
-    }
-    else {
-      _a.replaceWith(this.templateContent)
-    }
+    (_a = this.targetElement) === null || _a === void 0 ? void 0 : _a.prepend(this.templateContent);
   },
   remove() {
     var _a;
@@ -1264,13 +1254,6 @@ class StreamElement extends HTMLElement {
     }
     this.raise("target attribute is missing");
   }
-  get replaceIfPresentElement(){
-    var _a;
-    if (this.replaceIfPresent) {
-      return (_a = this.ownerDocument) === null || _a === void 0 ? void 0 : _a.getElementById(this.replaceIfPresent);
-    }
-    this.raise("target attribute is missing");
-  }
   get templateContent() {
     return this.templateElement.content;
   }
@@ -1285,9 +1268,6 @@ class StreamElement extends HTMLElement {
   }
   get target() {
     return this.getAttribute("target");
-  }
-  get replaceIfPresent(){
-    return this.getAttribute("replace_if_present");
   }
   raise(message) {
     throw new Error(`${this.description}: ${message}`);

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -9,20 +9,20 @@ module Turbo::Streams::Broadcasts
     broadcast_action_to *streamables, action: :remove, target: target
   end
 
-  def broadcast_replace_to(*streamables, target:, replace_if_present: nil, **rendering)
-    broadcast_action_to *streamables, action: :replace, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_replace_to(*streamables, target:, remove_if_present: nil, **rendering)
+    broadcast_action_to *streamables, action: :replace, target: target, remove_if_present: remove_if_present, **rendering
   end
 
-  def broadcast_append_to(*streamables, target:, replace_if_present: nil, **rendering)
-    broadcast_action_to *streamables, action: :append, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_append_to(*streamables, target:, remove_if_present: nil, **rendering)
+    broadcast_action_to *streamables, action: :append, target: target, remove_if_present: remove_if_present, **rendering
   end
 
-  def broadcast_prepend_to(*streamables, target:, replace_if_present: nil, **rendering)
-    broadcast_action_to *streamables, action: :prepend, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_prepend_to(*streamables, target:, remove_if_present: nil, **rendering)
+    broadcast_action_to *streamables, action: :prepend, target: target, remove_if_present: remove_if_present, **rendering
   end
 
-  def broadcast_action_to(*streamables, action:, target:, replace_if_present: nil, **rendering)
-    broadcast_stream_to *streamables, content: turbo_stream_action_tag(action, target: target, replace_if_present: replace_if_present, template:
+  def broadcast_action_to(*streamables, action:, target:, remove_if_present: nil, **rendering)
+    broadcast_stream_to *streamables, content: turbo_stream_action_tag(action, target: target, remove_if_present: remove_if_present, template:
       rendering.delete(:content) || (rendering.any? ? render_format(:html, **rendering) : nil)
     )
   end
@@ -32,17 +32,17 @@ module Turbo::Streams::Broadcasts
     broadcast_action_later_to *streamables, action: :replace, target: target, **rendering
   end
 
-  def broadcast_append_later_to(*streamables, target:, replace_if_present: nil, **rendering)
-    broadcast_action_later_to *streamables, action: :append, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_append_later_to(*streamables, target:, remove_if_present: nil, **rendering)
+    broadcast_action_later_to *streamables, action: :append, target: target, remove_if_present: remove_if_present, **rendering
   end
 
-  def broadcast_prepend_later_to(*streamables, target:, replace_if_present: nil, **rendering)
-    broadcast_action_later_to *streamables, action: :prepend, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_prepend_later_to(*streamables, target:, remove_if_present: nil, **rendering)
+    broadcast_action_later_to *streamables, action: :prepend, target: target, remove_if_present: remove_if_present, **rendering
   end
 
-  def broadcast_action_later_to(*streamables, action:, target:,replace_if_present: nil, **rendering)
+  def broadcast_action_later_to(*streamables, action:, target:,remove_if_present: nil, **rendering)
     Turbo::Streams::ActionBroadcastJob.perform_later \
-      stream_name_from(streamables), action: action, target: target, replace_if_present: replace_if_present, **rendering
+      stream_name_from(streamables), action: action, target: target, remove_if_present: remove_if_present, **rendering
   end
 
 

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -9,20 +9,20 @@ module Turbo::Streams::Broadcasts
     broadcast_action_to *streamables, action: :remove, target: target
   end
 
-  def broadcast_replace_to(*streamables, target:, **rendering)
-    broadcast_action_to *streamables, action: :replace, target: target, **rendering
+  def broadcast_replace_to(*streamables, target:, replace_if_present: nil, **rendering)
+    broadcast_action_to *streamables, action: :replace, target: target, replace_if_present: replace_if_present, **rendering
   end
 
-  def broadcast_append_to(*streamables, target:, **rendering)
-    broadcast_action_to *streamables, action: :append, target: target, **rendering
+  def broadcast_append_to(*streamables, target:, replace_if_present: nil, **rendering)
+    broadcast_action_to *streamables, action: :append, target: target, replace_if_present: replace_if_present, **rendering
   end
 
-  def broadcast_prepend_to(*streamables, target:, **rendering)
-    broadcast_action_to *streamables, action: :prepend, target: target, **rendering
+  def broadcast_prepend_to(*streamables, target:, replace_if_present: nil, **rendering)
+    broadcast_action_to *streamables, action: :prepend, target: target, replace_if_present: replace_if_present, **rendering
   end
 
-  def broadcast_action_to(*streamables, action:, target:, **rendering)
-    broadcast_stream_to *streamables, content: turbo_stream_action_tag(action, target: target, template:
+  def broadcast_action_to(*streamables, action:, target:, replace_if_present: nil, **rendering)
+    broadcast_stream_to *streamables, content: turbo_stream_action_tag(action, target: target, replace_if_present: replace_if_present, template:
       rendering.delete(:content) || (rendering.any? ? render_format(:html, **rendering) : nil)
     )
   end
@@ -32,17 +32,17 @@ module Turbo::Streams::Broadcasts
     broadcast_action_later_to *streamables, action: :replace, target: target, **rendering
   end
 
-  def broadcast_append_later_to(*streamables, target:, **rendering)
-    broadcast_action_later_to *streamables, action: :append, target: target, **rendering
+  def broadcast_append_later_to(*streamables, target:, replace_if_present: nil, **rendering)
+    broadcast_action_later_to *streamables, action: :append, target: target, replace_if_present: replace_if_present, **rendering
   end
 
-  def broadcast_prepend_later_to(*streamables, target:, **rendering)
-    broadcast_action_later_to *streamables, action: :prepend, target: target, **rendering
+  def broadcast_prepend_later_to(*streamables, target:, replace_if_present: nil, **rendering)
+    broadcast_action_later_to *streamables, action: :prepend, target: target, replace_if_present: replace_if_present, **rendering
   end
 
-  def broadcast_action_later_to(*streamables, action:, target:, **rendering)
+  def broadcast_action_later_to(*streamables, action:, target:,replace_if_present: nil, **rendering)
     Turbo::Streams::ActionBroadcastJob.perform_later \
-      stream_name_from(streamables), action: action, target: target, **rendering
+      stream_name_from(streamables), action: action, target: target, replace_if_present: replace_if_present, **rendering
   end
 
 

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -12,7 +12,8 @@ module Turbo::Streams::ActionHelper
 
     if replace_if_present
       replacement = convert_to_turbo_stream_dom_id(replace_if_present)
-      %(<turbo-stream action="#{action}" target="#{target}" replace_if_present="#{replacement}">#{template}</turbo-stream>).html_safe
+      %(<turbo-stream action="remove" target="#{replacement}"></turbo-stream>
+        <turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
     else
       %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
     end

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -6,11 +6,16 @@ module Turbo::Streams::ActionHelper
   #
   #   turbo_stream_action_tag "replace", target: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" target="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
-  def turbo_stream_action_tag(action, target:, template: nil)
+  def turbo_stream_action_tag(action, target:, template: nil, replace_if_present: nil)
     target   = convert_to_turbo_stream_dom_id(target)
     template = action.to_sym == :remove ? "" : "<template>#{template}</template>"
 
-    %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
+    if replace_if_present
+      replacement = convert_to_turbo_stream_dom_id(replace_if_present)
+      %(<turbo-stream action="#{action}" target="#{target}" replace_if_present="#{replacement}">#{template}</turbo-stream>).html_safe
+    else
+      %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
+    end
   end
 
   private

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -6,12 +6,15 @@ module Turbo::Streams::ActionHelper
   #
   #   turbo_stream_action_tag "replace", target: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" target="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
-  def turbo_stream_action_tag(action, target:, template: nil, replace_if_present: nil)
+  #
+  # If remove_if_present is specified, the helper will generate 2 tags (remove and the original action)
+  #
+  def turbo_stream_action_tag(action, target:, template: nil, remove_if_present: nil)
     target   = convert_to_turbo_stream_dom_id(target)
     template = action.to_sym == :remove ? "" : "<template>#{template}</template>"
 
-    if replace_if_present
-      replacement = convert_to_turbo_stream_dom_id(replace_if_present)
+    if remove_if_present
+      replacement = convert_to_turbo_stream_dom_id(remove_if_present)
       %(<turbo-stream action="remove" target="#{replacement}"></turbo-stream>
         <turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
     else

--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -1,6 +1,6 @@
 # The job that powers all the <tt>broadcast_$action_later</tt> broadcasts available in <tt>Turbo::Streams::Broadcasts</tt>.
 class Turbo::Streams::ActionBroadcastJob < ActiveJob::Base
-  def perform(stream, action:, target:, **rendering)
-    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target, **rendering
+  def perform(stream, action:, target:, replace_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target,replace_if_present: replace_if_present,  **rendering
   end
 end

--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -1,6 +1,6 @@
 # The job that powers all the <tt>broadcast_$action_later</tt> broadcasts available in <tt>Turbo::Streams::Broadcasts</tt>.
 class Turbo::Streams::ActionBroadcastJob < ActiveJob::Base
-  def perform(stream, action:, target:, replace_if_present: nil, **rendering)
-    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target,replace_if_present: replace_if_present,  **rendering
+  def perform(stream, action:, target:, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target,remove_if_present: remove_if_present,  **rendering
   end
 end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -51,15 +51,15 @@ module Turbo::Broadcastable
     #     belongs_to :board
     #     broadcasts_to ->(message) { [ message.board, :messages ] }, inserts_by: :prepend, target: "board_messages"
     #   end
-    def broadcasts_to(stream, inserts_by: :append, target: broadcast_target_default, replace_if_present: nil)
-      after_create_commit  -> { broadcast_action_later_to stream.try(:call, self) || send(stream), action: inserts_by, target: target, replace_if_present: replace_if_present.nil? ? nil : replace_if_present.try(:call, self) || send(replace_if_present) }
+    def broadcasts_to(stream, inserts_by: :append, target: broadcast_target_default, remove_if_present: nil)
+      after_create_commit  -> { broadcast_action_later_to stream.try(:call, self) || send(stream), action: inserts_by, target: target, remove_if_present: remove_if_present.nil? ? nil : remove_if_present.try(:call, self) || send(remove_if_present) }
       after_update_commit  -> { broadcast_replace_later_to stream.try(:call, self) || send(stream) }
       after_destroy_commit -> { broadcast_remove_to stream.try(:call, self) || send(stream) }
     end
 
     # Same as <tt>#broadcasts_to</tt>, but the designated stream is automatically set to the current model.
-    def broadcasts(inserts_by: :append, target: broadcast_target_default, replace_if_present: nil)
-      after_create_commit  -> { broadcast_action_later action: inserts_by, target: target, replace_if_present: replace_if_present.nil? ? nil : replace_if_present.try(:call, self) || send(replace_if_present) }
+    def broadcasts(inserts_by: :append, target: broadcast_target_default, remove_if_present: nil)
+      after_create_commit  -> { broadcast_action_later action: inserts_by, target: target, remove_if_present: remove_if_present.nil? ? nil : remove_if_present.try(:call, self) || send(remove_if_present) }
       after_update_commit  -> { broadcast_replace_later }
       after_destroy_commit -> { broadcast_remove }
     end
@@ -105,7 +105,10 @@ module Turbo::Broadcastable
 
   # Append a rendering of this broadcastable model to the target identified by it's dom id passed as <tt>target</tt>
   # for subscribers of the stream name identified by the passed <tt>streamables</tt>. The rendering parameters can be set by
-  # appending named arguments to the call. Examples:
+  # appending named arguments to the call.
+  # If a dom id is passed as <tt>remove_if_present</tt>, the matching element will be removed before appending
+  #
+  # Examples:
   #
   #   # Sends <turbo-stream action="append" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
   #   # to the stream named "identity:2:clearances"
@@ -115,18 +118,28 @@ module Turbo::Broadcastable
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_append_to examiner.identity, :clearances, target: "clearances",
   #     partial: "clearances/other_partial", locals: { a: 1 }
-  def broadcast_append_to(*streamables, target: broadcast_target_default, replace_if_present: nil, **rendering)
-    Turbo::StreamsChannel.broadcast_append_to *streamables, target: target, replace_if_present: replace_if_present, **broadcast_rendering_with_defaults(rendering)
+  #
+  #   # Sends:
+  #   #       <turbo-stream action="remove" target="clearance_5"><template>
+  #   #       <turbo-stream action="append" target="clearances"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.broadcast_append_to examiner.identity, :clearances, target: "clearances", remove_if_present: clearance,
+  #     partial: "clearances/other_partial", locals: { a: 1 }
+  def broadcast_append_to(*streamables, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_append_to *streamables, target: target, remove_if_present: remove_if_present, **broadcast_rendering_with_defaults(rendering)
   end
 
   # Same as <tt>#broadcast_append_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_append(target: broadcast_target_default, replace_if_present: nil, **rendering)
-    broadcast_append_to self, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_append(target: broadcast_target_default, remove_if_present: nil, **rendering)
+    broadcast_append_to self, target: target, remove_if_present: remove_if_present, **rendering
   end
 
   # Prepend a rendering of this broadcastable model to the target identified by it's dom id passed as <tt>target</tt>
   # for subscribers of the stream name identified by the passed <tt>streamables</tt>. The rendering parameters can be set by
-  # appending named arguments to the call. Examples:
+  # appending named arguments to the call.
+  # If a dom id is passed as <tt>remove_if_present</tt>, the matching element will be removed before appending
+  #
+  # Examples:
   #
   #   # Sends <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
   #   # to the stream named "identity:2:clearances"
@@ -136,27 +149,35 @@ module Turbo::Broadcastable
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_prepend_to examiner.identity, :clearances, target: "clearances",
   #     partial: "clearances/other_partial", locals: { a: 1 }
-  def broadcast_prepend_to(*streamables, target: broadcast_target_default, replace_if_present: nil, **rendering)
-    Turbo::StreamsChannel.broadcast_prepend_to *streamables, target: target, replace_if_present: replace_if_present, **broadcast_rendering_with_defaults(rendering)
+  #
+  #   # Sends:
+  #   #       <turbo-stream action="remove" target="clearance_5"><template>
+  #   #       <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.broadcast_prepend_to examiner.identity, :clearances, target: "clearances", remove_if_present: clearance,
+  #     partial: "clearances/other_partial", locals: { a: 1 }
+  def broadcast_prepend_to(*streamables, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_prepend_to *streamables, target: target, remove_if_present: remove_if_present, **broadcast_rendering_with_defaults(rendering)
   end
 
   # Same as <tt>#broadcast_prepend_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_prepend(target: broadcast_target_default, replace_if_present: nil, **rendering)
-    broadcast_prepend_to self, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_prepend(target: broadcast_target_default, remove_if_present: nil, **rendering)
+    broadcast_prepend_to self, target: target, remove_if_present: remove_if_present, **rendering
   end
 
   # Broadcast a named <tt>action</tt>, allowing for dynamic dispatch, instead of using the concrete action methods. Examples:
+  # extra parameter <tt>remove_if_present</tt> for :append and :prepend can also be passed
   #
   #   # Sends <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_action_to examiner.identity, :clearances, action: :prepend, target: "clearances"
-  def broadcast_action_to(*streamables, action:, target: broadcast_target_default, replace_if_present: nil, **rendering)
-    Turbo::StreamsChannel.broadcast_action_to(*streamables, action: action, target: target, replace_if_present: nil, **broadcast_rendering_with_defaults(rendering))
+  def broadcast_action_to(*streamables, action:, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_action_to(*streamables, action: action, target: target, remove_if_present: remove_if_present, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_action_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_action(action, target: broadcast_target_default, replace_if_present: nil, **rendering)
-    broadcast_action_to self, action: action, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_action(action, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    broadcast_action_to self, action: action, target: target, remove_if_present: remove_if_present, **rendering
   end
 
 
@@ -171,33 +192,33 @@ module Turbo::Broadcastable
   end
 
   # Same as <tt>broadcast_append_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
-  def broadcast_append_later_to(*streamables, target: broadcast_target_default, replace_if_present: nil, **rendering)
-    Turbo::StreamsChannel.broadcast_append_later_to *streamables, target: target, replace_if_present: replace_if_present, **broadcast_rendering_with_defaults(rendering)
+  def broadcast_append_later_to(*streamables, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_append_later_to *streamables, target: target, remove_if_present: remove_if_present, **broadcast_rendering_with_defaults(rendering)
   end
 
   # Same as <tt>#broadcast_append_later_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_append_later(target: broadcast_target_default, replace_if_present: nil, **rendering)
-    broadcast_append_later_to self, target: target,replace_if_present: replace_if_present, **rendering
+  def broadcast_append_later(target: broadcast_target_default, remove_if_present: nil, **rendering)
+    broadcast_append_later_to self, target: target,remove_if_present: remove_if_present, **rendering
   end
 
   # Same as <tt>broadcast_prepend_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
-  def broadcast_prepend_later_to(*streamables, target: broadcast_target_default, replace_if_present: nil, **rendering)
-    Turbo::StreamsChannel.broadcast_prepend_later_to *streamables, target: target, replace_if_present: replace_if_present, **broadcast_rendering_with_defaults(rendering)
+  def broadcast_prepend_later_to(*streamables, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_prepend_later_to *streamables, target: target, remove_if_present: remove_if_present, **broadcast_rendering_with_defaults(rendering)
   end
 
   # Same as <tt>#broadcast_prepend_later_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_prepend_later(target: broadcast_target_default, replace_if_present: nil, **rendering)
-    broadcast_prepend_later_to self, target: target, replace_if_present: replace_if_present, **rendering
+  def broadcast_prepend_later(target: broadcast_target_default, remove_if_present: nil, **rendering)
+    broadcast_prepend_later_to self, target: target, remove_if_present: remove_if_present, **rendering
   end
 
   # Same as <tt>broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
-  def broadcast_action_later_to(*streamables, action:, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, target: target, **broadcast_rendering_with_defaults(rendering))
+  def broadcast_action_later_to(*streamables, action:, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, target: target, remove_if_present: remove_if_present, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_action_later_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_action_later(action:, target: broadcast_target_default, **rendering)
-    broadcast_action_later_to self, action: action, target: target, **rendering
+  def broadcast_action_later(action:, target: broadcast_target_default, remove_if_present: nil, **rendering)
+    broadcast_action_later_to self, action: action, target: target, remove_if_present: remove_if_present, **rendering
   end
 
 

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -76,8 +76,14 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.append "clearances" do %>
   #     <div id='clearance_5'>Append this to .clearances</div>
   #   <% end %>
-  def append(target, content = nil, **rendering, &block)
-    action :append, target, content, **rendering, &block
+  #
+  # If <tt>replace_if_present</tt> is passed as an argument, the method will first attempt to find a dom element
+  # matching <tt>replace_if_present</tt> (in the form of a dom element identifier like <tt>target</tt>).
+  # If an element is found, it will be replaced by the rendering result, otherwise the rendering result will be
+  # appended to the target.
+  #
+  def append(target, content = nil, replace_if_present: nil, **rendering, &block)
+    action :append, target, content, replace_if_present: replace_if_present, **rendering, &block
   end
 
   # Prepend to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -90,23 +96,29 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.prepend "clearances" do %>
   #     <div id='clearance_5'>Prepend this to .clearances</div>
   #   <% end %>
-  def prepend(target, content = nil, **rendering, &block)
-    action :prepend, target, content, **rendering, &block
+  #
+  # If <tt>replace_if_present</tt> is passed as an argument, the method will first attempt to find a dom element
+  # matching <tt>replace_if_present</tt> (in the form of a dom element identifier like <tt>target</tt>).
+  # If an element is found, it will be replaced by the rendering result, otherwise the rendering result will be
+  # prepended to the target.
+  #
+  def prepend(target, content = nil, replace_if_present: nil, **rendering, &block)
+    action :prepend, target, content, replace_if_present: replace_if_present, **rendering, &block
   end
 
   # Send an action of the type <tt>name</tt>. Options described in the concrete methods.
-  def action(name, target, content = nil, allow_inferred_rendering: true, **rendering, &block)
+  def action(name, target, content = nil, allow_inferred_rendering: true, replace_if_present: nil, **rendering, &block)
     target_name = extract_target_name_from(target)
 
     case
     when content
-      turbo_stream_action_tag name, target: target_name, template: (render_record(content) if allow_inferred_rendering) || content
+      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: (render_record(content) if allow_inferred_rendering) || content
     when block_given?
-      turbo_stream_action_tag name, target: target_name, template: @view_context.capture(&block)
+      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: @view_context.capture(&block)
     when rendering.any?
-      turbo_stream_action_tag name, target: target_name, template: @view_context.render(formats: [ :html ], **rendering)
+      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: @view_context.render(formats: [ :html ], **rendering)
     else
-      turbo_stream_action_tag name, target: target_name, template: (render_record(target) if allow_inferred_rendering)
+      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: (render_record(target) if allow_inferred_rendering)
     end
   end
 

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -77,13 +77,12 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_5'>Append this to .clearances</div>
   #   <% end %>
   #
-  # If <tt>replace_if_present</tt> is passed as an argument, the method will first attempt to find a dom element
-  # matching <tt>replace_if_present</tt> (in the form of a dom element identifier like <tt>target</tt>).
-  # If an element is found, it will be replaced by the rendering result, otherwise the rendering result will be
-  # appended to the target.
+  # If <tt>remove_if_present</tt> is passed as an argument, the method will first attempt to find a dom element
+  # matching <tt>remove_if_present</tt> (in the form of a dom element identifier like <tt>target</tt>) and remove
+  # it before appending the rendering result.
   #
-  def append(target, content = nil, replace_if_present: nil, **rendering, &block)
-    action :append, target, content, replace_if_present: replace_if_present, **rendering, &block
+  def append(target, content = nil, remove_if_present: nil, **rendering, &block)
+    action :append, target, content, remove_if_present: remove_if_present, **rendering, &block
   end
 
   # Prepend to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -97,28 +96,27 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_5'>Prepend this to .clearances</div>
   #   <% end %>
   #
-  # If <tt>replace_if_present</tt> is passed as an argument, the method will first attempt to find a dom element
-  # matching <tt>replace_if_present</tt> (in the form of a dom element identifier like <tt>target</tt>).
-  # If an element is found, it will be replaced by the rendering result, otherwise the rendering result will be
-  # prepended to the target.
+  # If <tt>remove_if_present</tt> is passed as an argument, the method will first attempt to find a dom element
+  # matching <tt>remove_if_present</tt> (in the form of a dom element identifier like <tt>target</tt>) and remove
+  # it before prepending the rendering result.
   #
-  def prepend(target, content = nil, replace_if_present: nil, **rendering, &block)
-    action :prepend, target, content, replace_if_present: replace_if_present, **rendering, &block
+  def prepend(target, content = nil, remove_if_present: nil, **rendering, &block)
+    action :prepend, target, content, remove_if_present: remove_if_present, **rendering, &block
   end
 
   # Send an action of the type <tt>name</tt>. Options described in the concrete methods.
-  def action(name, target, content = nil, allow_inferred_rendering: true, replace_if_present: nil, **rendering, &block)
+  def action(name, target, content = nil, allow_inferred_rendering: true, remove_if_present: nil, **rendering, &block)
     target_name = extract_target_name_from(target)
 
     case
     when content
-      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: (render_record(content) if allow_inferred_rendering) || content
+      turbo_stream_action_tag name, target: target_name, remove_if_present: remove_if_present, template: (render_record(content) if allow_inferred_rendering) || content
     when block_given?
-      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: @view_context.capture(&block)
+      turbo_stream_action_tag name, target: target_name, remove_if_present: remove_if_present, template: @view_context.capture(&block)
     when rendering.any?
-      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: @view_context.render(formats: [ :html ], **rendering)
+      turbo_stream_action_tag name, target: target_name, remove_if_present: remove_if_present, template: @view_context.render(formats: [ :html ], **rendering)
     else
-      turbo_stream_action_tag name, target: target_name, replace_if_present: replace_if_present, template: (render_record(target) if allow_inferred_rendering)
+      turbo_stream_action_tag name, target: target_name, remove_if_present: remove_if_present, template: (render_record(target) if allow_inferred_rendering)
     end
   end
 

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -36,11 +36,19 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting append to stream now with removed element" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("append", target: "messages", remove_if_present: "message_1", template: "<p>Hello!</p>") do
+      @message.broadcast_append_to "stream", remove_if_present: "message_1"
+    end
+  end
+
+
   test "broadcasting append to stream with custom target now" do
     assert_broadcast_on "stream", turbo_stream_action_tag("append", target: "board_messages", template: "<p>Hello!</p>") do
       @message.broadcast_append_to "stream", target: "board_messages"
     end
   end
+
 
   test "broadcasting append now" do
     assert_broadcast_on @message.to_param, turbo_stream_action_tag("append", target: "messages", template: "<p>Hello!</p>") do
@@ -54,11 +62,18 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting prepend to stream now and remove element" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("prepend", target: "messages", remove_if_present: "message_1", template: "<p>Hello!</p>") do
+      @message.broadcast_prepend_to "stream", remove_if_present: "message_1"
+    end
+  end
+
   test "broadcasting prepend to stream with custom target now" do
     assert_broadcast_on "stream", turbo_stream_action_tag("prepend", target: "board_messages", template: "<p>Hello!</p>") do
       @message.broadcast_prepend_to "stream", target: "board_messages"
     end
   end
+
 
   test "broadcasting prepend now" do
     assert_broadcast_on @message.to_param, turbo_stream_action_tag("prepend", target: "messages", template: "<p>Hello!</p>") do
@@ -75,6 +90,12 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   test "broadcasting action now" do
     assert_broadcast_on @message.to_param, turbo_stream_action_tag("prepend", target: "messages", template: "<p>Hello!</p>") do
       @message.broadcast_action "prepend"
+    end
+  end
+
+  test "broadcasting action now with remove element" do
+    assert_broadcast_on @message.to_param, turbo_stream_action_tag("prepend", target: "messages", remove_if_present: "message_1", template: "<p>Hello!</p>") do
+      @message.broadcast_action "prepend", remove_if_present: "message_1"
     end
   end
 

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -33,6 +33,13 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting append now with remove_if_present" do
+    message = Message.new(record_id: 1, content: "hello!")
+    assert_broadcast_on "stream", turbo_stream_action_tag("append", target: "messages", remove_if_present: "message_1", template: "<p>hello!</p>") do
+      Turbo::StreamsChannel.broadcast_append_to "stream", target: "messages", remove_if_present: message, partial: "messages/message", locals: { message: message.content }
+    end
+  end
+
   test "broadcasting append now with empty template" do
     assert_broadcast_on "stream", %(<turbo-stream action="append" target="message_1"><template></template></turbo-stream>) do
       Turbo::StreamsChannel.broadcast_append_to "stream", target: "message_1", content: ""
@@ -42,6 +49,13 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
   test "broadcasting prepend now" do
     assert_broadcast_on "stream", turbo_stream_action_tag("prepend", target: "messages", template: "<p>hello!</p>") do
       Turbo::StreamsChannel.broadcast_prepend_to "stream", target: "messages", partial: "messages/message", locals: { message: "hello!" }
+    end
+  end
+
+  test "broadcasting prepend now with remove_if_present" do
+    message = Message.new(record_id: 1, content: "hello!")
+    assert_broadcast_on "stream", turbo_stream_action_tag("prepend", target: "messages", remove_if_present: "message_1", template: "<p>hello!</p>") do
+      Turbo::StreamsChannel.broadcast_prepend_to "stream", target: "messages", remove_if_present: message, partial: "messages/message", locals: { message: message.content }
     end
   end
 


### PR DESCRIPTION
This is a request for comments/opinions.

In the demo app, @dhh specifically commented out the turbo_stream response to the action to avoid double rendering the message: https://github.com/hotwired/hotwire-rails-demo-chat/blob/0fb439d756ac59a1dd41c978973cc04d0517edd4/app/views/messages/create.turbo_stream.erb#L1

The problem with this approach is that
- it's not resilient to broken action cable connection (unlike a turbo_stream response to the action)
- there is a delay from the sender of the message (the background job needs to be executed, then sent through action cable)

One potential solution to this is to perform the action twice (once in the turbo_stream response, one in the broadcast job) but make the action idempotent.

What do you think about augmenting append and prepend with an 'upsert'-like function whereby:
- if an dom id is present, the rendered template will replace the matching element
- otherwise, the append/prepend method will add the contents of the rendered template to the target container (as per the existing)

This way, the first response (likely the turbo_stream) will append the message to the container, and the second action (from the broadcast job) will replace the message in place.

I took a crack at it in this PR by passing a `replace_if_present:` option to the append and prepend calls (and related methods).

On the plus side, it makes the client code fairly easy (add `replace_if_present` to both the Turbo::Streams::ActionBroadcastJob and the turbo_stream response) as per this commit: https://github.com/jeromecornet/hotwire-rails-demo-chat/commit/696e1c91b8eef2d64d54d387bf1462526aca5fd8

But the code looks not very pretty, as it introduces an append & prepend -specific option in many methods throughout the code.

What do you think of this approach ? Do you think it would be worth pursuing ? Any ideas on solving it better ?

If you think it's a good idea, I will clean this up before submitting a proper PR.
