### PR TITLE
Pass the model instance to the partial renderer using local variables.

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -265,7 +265,9 @@ module Turbo::Broadcastable
 
     def broadcast_rendering_with_defaults(options)
       options.tap do |o|
-        o[:object] ||= self
+        # Add the current instance into the locals with the element name (which is the un-namespaced name)
+        # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
+        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
         o[:partial] ||= to_partial_path
       end
     end

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -96,6 +96,13 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
       @profile.broadcast_replace
     end
   end
+
+  test "partials don't get overwritten if they collide with the template name" do
+    @profile = Users::Profile.new(id: 1, name: "Ryan")
+    assert_broadcast_on @profile.to_param, turbo_stream_action_tag("replace", target: "users_profile_1", template: "<p>Hello!</p>") do
+      @profile.broadcast_replace partial: 'messages/message', locals: { message: @message }
+    end
+  end
 end
 
 class Turbo::BroadcastableArticleTest < ActionCable::Channel::TestCase


### PR DESCRIPTION
This reverts part of #103, which cause the ActionView::ObjectRenderer to be used.  This had the undesired consequence of overwriting local variables explicitly passed in if they had the same name as the partial.

Fixes #186