### PR TITLE
Turbo::Streams::TagBuilder can set targets attribute on stream tag

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -6,11 +6,20 @@ module Turbo::Streams::ActionHelper
   #
   #   turbo_stream_action_tag "replace", target: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" target="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
-  def turbo_stream_action_tag(action, target:, template: nil)
-    target   = convert_to_turbo_stream_dom_id(target)
+  #
+  #   turbo_stream_action_tag "replace", targets: "message_1", template: %(<div id="message_1">Hello!</div>)
+  #   # => <turbo-stream action="replace" targets="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
+  def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil)
     template = action.to_sym == :remove ? "" : "<template>#{template}</template>"
 
-    %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
+    if target
+      target = convert_to_turbo_stream_dom_id(target)
+      %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
+    elsif targets
+      %(<turbo-stream action="#{action}" targets="#{targets}">#{template}</turbo-stream>).html_safe
+    else
+      raise ArgumentError, "target or targets must be supplied"
+    end
   end
 
   private

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -40,6 +40,16 @@ class Turbo::Streams::TagBuilder
     action :remove, target, allow_inferred_rendering: false
   end
 
+  # Removes the <tt>targets</tt> from the dom. The targets can either be a CSS selector string or an object that responds to
+  # <tt>to_key</tt>, which is then called and passed through <tt>ActionView::RecordIdentifier.dom_id</tt> (all Active Records
+  # do). Examples:
+  #
+  #   <%= turbo_stream.remove_all ".clearance_item" %>
+  #   <%= turbo_stream.remove_all clearance %>
+  def remove_all(targets)
+    action_all :remove, targets, allow_inferred_rendering: false
+  end
+
   # Replace the <tt>target</tt> in the dom with the either the <tt>content</tt> passed in, a rendering result determined
   # by the <tt>rendering</tt> keyword arguments, the content in the block, or the rendering of the target as a record. Examples:
   #
@@ -51,6 +61,19 @@ class Turbo::Streams::TagBuilder
   #   <% end %>
   def replace(target, content = nil, **rendering, &block)
     action :replace, target, content, **rendering, &block
+  end
+
+  # Replace the <tt>targets</tt> in the dom with the either the <tt>content</tt> passed in, a rendering result determined
+  # by the <tt>rendering</tt> keyword arguments, the content in the block, or the rendering of the target as a record. Examples:
+  #
+  #   <%= turbo_stream.replace_all ".clearance_item", "<div class='clearance_item'>Replace the dom target identified by the class clearance_item</div>" %>
+  #   <%= turbo_stream.replace_all clearance %>
+  #   <%= turbo_stream.replace_all clearance, partial: "clearances/clearance", locals: { title: "Hello" } %>
+  #   <%= turbo_stream.replace_all ".clearance_item" do %>
+  #     <div class='.clearance_item'>Replace the dom target identified by the class clearance_item</div>
+  #   <% end %>
+  def replace_all(targets, content = nil, **rendering, &block)
+    action_all :replace, targets, content, **rendering, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -67,6 +90,19 @@ class Turbo::Streams::TagBuilder
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
+  # the content in the block, or the rendering of the target as a record before the <tt>targets</tt> in the dom. Examples:
+  #
+  #   <%= turbo_stream.before_all ".clearance_item", "<div class='clearance_item'>Insert before the dom target identified by the class clearance_item</div>" %>
+  #   <%= turbo_stream.before_all clearance %>
+  #   <%= turbo_stream.before_all clearance, partial: "clearances/clearance", locals: { title: "Hello" } %>
+  #   <%= turbo_stream.before_all ".clearance_item" do %>
+  #     <div class='clearance_item'>Insert before the dom target identified by clearance_item</div>
+  #   <% end %>
+  def before_all(targets, content = nil, **rendering, &block)
+    action_all :before, targets, content, **rendering, &block
+  end
+
+  # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
   # the content in the block, or the rendering of the target as a record after the <tt>target</tt> in the dom. Examples:
   #
   #   <%= turbo_stream.after "clearance_5", "<div id='clearance_6'>Insert after the dom target identified by clearance_5</div>" %>
@@ -77,6 +113,19 @@ class Turbo::Streams::TagBuilder
   #   <% end %>
   def after(target, content = nil, **rendering, &block)
     action :after, target, content, **rendering, &block
+  end
+
+  # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
+  # the content in the block, or the rendering of the target as a record after the <tt>targets</tt> in the dom. Examples:
+  #
+  #   <%= turbo_stream.after_all ".clearance_item", "<div class='clearance_item'>Insert after the dom target identified by the class clearance_item</div>" %>
+  #   <%= turbo_stream.after_all clearance %>
+  #   <%= turbo_stream.after_all clearance, partial: "clearances/clearance", locals: { title: "Hello" } %>
+  #   <%= turbo_stream.after_all "clearance_item" do %>
+  #     <div class='clearance_item'>Insert after the dom target identified by the class clearance_item</div>
+  #   <% end %>
+  def after_all(targets, content = nil, **rendering, &block)
+    action_all :after, targets, content, **rendering, &block
   end
 
   # Update the <tt>target</tt> in the dom with the either the <tt>content</tt> passed in or a rendering result determined
@@ -90,6 +139,19 @@ class Turbo::Streams::TagBuilder
   #   <% end %>
   def update(target, content = nil, **rendering, &block)
     action :update, target, content, **rendering, &block
+  end
+
+  # Update the <tt>targets</tt> in the dom with the either the <tt>content</tt> passed in or a rendering result determined
+  # by the <tt>rendering</tt> keyword arguments, the content in the block, or the rendering of the targets as a record. Examples:
+  #
+  #   <%= turbo_stream.update_all "clearance_item", "Update the content of the dom target identified by the class clearance_item" %>
+  #   <%= turbo_stream.update_all clearance %>
+  #   <%= turbo_stream.update_all clearance, partial: "clearances/new_clearance", locals: { title: "Hello" } %>
+  #   <%= turbo_stream.update_all "clearance_item" do %>
+  #     Update the content of the dom target identified by the class clearance_item
+  #   <% end %>
+  def update_all(targets, content = nil, **rendering, &block)
+    action_all :update, targets, content, **rendering, &block
   end
 
   # Append to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -106,6 +168,20 @@ class Turbo::Streams::TagBuilder
     action :append, target, content, **rendering, &block
   end
 
+  # Append to the targets in the dom identified with <tt>targets</tt> either the <tt>content</tt> passed in or a
+  # rendering result determined by the <tt>rendering</tt> keyword arguments, the content in the block,
+  # or the rendering of the content as a record. Examples:
+  #
+  #   <%= turbo_stream.append_all ".clearances", "<div class='clearance_item'>Append this to .clearance_group</div>" %>
+  #   <%= turbo_stream.append_all ".clearances", clearance %>
+  #   <%= turbo_stream.append_all ".clearances", partial: "clearances/new_clearance", locals: { clearance: clearance } %>
+  #   <%= turbo_stream.append_all ".clearances" do %>
+  #     <div id='clearance_item'>Append this to .clearances</div>
+  #   <% end %>
+  def append_all(targets, content = nil, **rendering, &block)
+    action_all :append, targets, content, **rendering, &block
+  end
+
   # Prepend to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
   # rendering result determined by the <tt>rendering</tt> keyword arguments or the content in the block,
   # or the rendering of the content as a record. Examples:
@@ -120,20 +196,34 @@ class Turbo::Streams::TagBuilder
     action :prepend, target, content, **rendering, &block
   end
 
-  # Send an action of the type <tt>name</tt>. Options described in the concrete methods.
+  # Prepend to the targets in the dom identified with <tt>targets</tt> either the <tt>content</tt> passed in or a
+  # rendering result determined by the <tt>rendering</tt> keyword arguments or the content in the block,
+  # or the rendering of the content as a record. Examples:
+  #
+  #   <%= turbo_stream.prepend_all ".clearances", "<div class='clearance_item'>Prepend this to .clearances</div>" %>
+  #   <%= turbo_stream.prepend_all ".clearances", clearance %>
+  #   <%= turbo_stream.prepend_all ".clearances", partial: "clearances/new_clearance", locals: { clearance: clearance } %>
+  #   <%= turbo_stream.prepend_all ".clearances" do %>
+  #     <div class='clearance_item'>Prepend this to .clearances</div>
+  #   <% end %>
+  def prepend_all(targets, content = nil, **rendering, &block)
+    action_all :prepend, targets, content, **rendering, &block
+  end
+
+  # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
   def action(name, target, content = nil, allow_inferred_rendering: true, **rendering, &block)
     target_name = extract_target_name_from(target)
+    template = render_template(target, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
-    case
-    when content
-      turbo_stream_action_tag name, target: target_name, template: (render_record(content) if allow_inferred_rendering) || content
-    when block_given?
-      turbo_stream_action_tag name, target: target_name, template: @view_context.capture(&block)
-    when rendering.any?
-      turbo_stream_action_tag name, target: target_name, template: @view_context.render(formats: [ :html ], **rendering)
-    else
-      turbo_stream_action_tag name, target: target_name, template: (render_record(target) if allow_inferred_rendering)
-    end
+    turbo_stream_action_tag name, target: target_name, template: template
+  end
+
+  # Send an action of the type <tt>name</tt> to <tt>targets</tt>. Options described in the concrete methods.
+  def action_all(name, targets, content = nil, allow_inferred_rendering: true, **rendering, &block)
+    targets_name = extract_target_name_from(targets)
+    template = render_template(targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
+
+    turbo_stream_action_tag name, targets: targets_name, template: template
   end
 
   private
@@ -142,6 +232,19 @@ class Turbo::Streams::TagBuilder
         ActionView::RecordIdentifier.dom_id(target)
       else
         target
+      end
+    end
+
+    def render_template(target, content = nil, allow_inferred_rendering: true, **rendering, &block)
+      case
+      when content
+        allow_inferred_rendering ? (render_record(content) || content) : content
+      when block_given?
+        @view_context.capture(&block)
+      when rendering.any?
+        @view_context.render(formats: [ :html ], **rendering)
+      else
+        render_record(target) if allow_inferred_rendering
       end
     end
 

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -9,4 +9,8 @@ class MessagesController < ApplicationController
       format.turbo_stream { render turbo_stream: turbo_stream.append(:messages, "message_1"), status: :created }
     end
   end
+
+  def update
+    @message = Message.new(record_id: 1, content: "My message")
+  end
 end

--- a/test/dummy/app/views/messages/update.turbo_stream.erb
+++ b/test/dummy/app/views/messages/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.remove_all @message %>
+<%= turbo_stream.replace_all @message %>
+<%= turbo_stream.replace_all @message, "Something else" %>
+<%= turbo_stream.replace_all "message_5", "Something fifth" %>
+<%= turbo_stream.replace_all "message_5", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.append_all "messages", @message %>
+<%= turbo_stream.append_all "messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.prepend_all "messages", @message %>
+<%= turbo_stream.prepend_all "messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -27,6 +27,21 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
     STREAM
   end
 
+  test "update all turbo actions for multiple targets" do
+    patch message_path(id: 1), as: :turbo_stream
+    assert_dom_equal <<~STREAM, @response.body
+      <turbo-stream action="remove" targets="message_1"></turbo-stream>
+      <turbo-stream action="replace" targets="message_1"><template><p>My message</p></template></turbo-stream>
+      <turbo-stream action="replace" targets="message_1"><template>Something else</template></turbo-stream>
+      <turbo-stream action="replace" targets="message_5"><template>Something fifth</template></turbo-stream>
+      <turbo-stream action="replace" targets="message_5"><template><p>OLLA!</p></template></turbo-stream>
+      <turbo-stream action="append" targets="messages"><template><p>My message</p></template></turbo-stream>
+      <turbo-stream action="append" targets="messages"><template><p>OLLA!</p></template></turbo-stream>
+      <turbo-stream action="prepend" targets="messages"><template><p>My message</p></template></turbo-stream>
+      <turbo-stream action="prepend" targets="messages"><template><p>OLLA!</p></template></turbo-stream>
+    STREAM
+  end
+
   test "includes html format when rendering turbo_stream actions" do
     post posts_path, as: :turbo_stream
     assert_dom_equal <<~STREAM.chomp, @response.body


### PR DESCRIPTION
Background: https://github.com/hotwired/turbo/pull/113 allowed for multiple targets in turbo frame streams. This attempts to expose the feature to the Rails turbo_stream tag helper. Instead of a `target` which results in a call to `document.getElementById` on the JS level, a `targets` attribute will be passed into `document.querySelectorAll`

This adds the functionality to the tag builder. All "action methods" now have an `_all` variant which is piped into a new `action_all` method. The only real difference in these methods is the end result is setting `targets` instead of `target` in `turbo_stream_action_tag` which has also been updated to handle this feature.

I purposefully did not touch the ActionCable-related part of the gem as I think its usecase is mostly geared to always updating one element at a time. Regardless, if it were to get this feature, I think it would be better in a separate pull request. For now, I think giving the developer the ability to target multiple elements at once in the turbo stream response from a controller is ok for now.

The test included is pretty much a copy/paste of an existing test, but invoking the new code path.