### PR TITLE
Fix typo in upgrade docs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -94,7 +94,7 @@ end
 ```
 
 ## 3. Replace the inclusion of turbolinks in your pack file with turbo
-You probably have something like `require("turbolinks").start()`, which needs to become `import "@hotwired/turbo"`. You don't need to start anything. Turbo is automatically started (and assigned to `window.Turbo`) upon importation.
+You probably have something like `require("turbolinks").start()`, which needs to become `import "@hotwired/turbo-rails"`. You don't need to start anything. Turbo is automatically started (and assigned to `window.Turbo`) upon importation.
 
 
 ## 4. Replace all turbolinks namespaces with turbo


### PR DESCRIPTION
The upgrade instructions suggest that you use `import "@hotwired/turbo"` in your pack file, but the main docs for `turbo-rails` as well as the installer script `rake turbo:install` actually use `import "@hotwired/turbo-rails"`. 

This change fixes that so that all of the instructions are consistent.