### PR TITLE
Turbo frame identifier prefixing

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -19,12 +19,15 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag "tray", src: tray_path(tray), loading: "lazy" %>
   #   # => <turbo-frame id="tray" src="http://example.com/trays/1" loading="lazy"></turbo-frame>
   #
+  #   <%= turbo_frame_tag tray, :shared %>
+  #   # => <turbo-frame id="shared_tray_1"></turbo-frame>
+  #
   #   <%= turbo_frame_tag "tray" do %>
   #     <div>My tray frame!</div>
   #   <% end %>
   #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
-  def turbo_frame_tag(id, src: nil, target: nil, **attributes, &block)
-    id = id.respond_to?(:to_key) ? dom_id(id) : id
+  def turbo_frame_tag(id, prefix = nil, src: nil, target: nil, **attributes, &block)
+    id = id.respond_to?(:to_key) ? dom_id(id, prefix) : id
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -21,6 +21,12 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
   end
 
+  test "frame with model argument and prefix" do
+    record = Message.new(record_id: "1", content: "ignored")
+
+    assert_dom_equal %(<turbo-frame id="shared_message_1"></turbo-frame>), turbo_frame_tag(record, :shared)
+  end
+
   test "block style" do
     assert_dom_equal(%(<turbo-frame id="tray"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
   end


### PR DESCRIPTION
## What

Add a little helper to easily prefix turbo frame identifiers.

## Why

Your models don't always live in a single top-level namespace. Eg in some applications a resource can be both private and publicly accessible:

```rb
# config/routes.rb

namespace :public do
  resources :posts, only: :show
end

namespace :private do
  resources :posts, only: :show
end
```

These resources can look visually differently or behave differently so it can make sense to target these by a different identifier.

## Example

__Before:__

```erb
<%= turbo_frame_tag dom_id(message, :shared) do %>
  <article></article>
<% end %>
```

__After:__

```erb
<%= turbo_frame_tag message, :shared do %>
  <article></article>
<% end %>
```