### PR TITLE
Fix typo in development section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Turbo can coexist with Rails UJS, but you need to take a series of upgrade steps
 
 * To run the Rails tests: `bundle exec rake`.
   * To install dependencies: `bundle install`
-  * To prepare the test database: `cd tests/dummy; RAILS_ENV=test ./bin/rails db:migrate`
+  * To prepare the test database: `cd test/dummy; RAILS_ENV=test ./bin/rails db:migrate`
 * To compile the JavaScript for the asset pipeline: `yarn build`
 
 


### PR DESCRIPTION
This PR fixes a typo in development section of README file, more specifically it fixes the name of folder that contains the tests from `tests` to `test`