### PR TITLE
Fix broken namespace and add example importmap pin in instructions

### DIFF
--- a/lib/install/turbo_with_asset_pipeline.rb
+++ b/lib/install/turbo_with_asset_pipeline.rb
@@ -3,7 +3,7 @@ if (app_js_path = Rails.root.join("app/javascript/application.js")).exist?
   append_to_file app_js_path, %(import "@hotwired/turbo-rails"\n)
 else
   say <<~INSTRUCTIONS, :red
-    You must import @hotwire/turbo-rails in your application.js.
+    You must import @hotwired/turbo-rails in your application.js.
   INSTRUCTIONS
 end
 
@@ -15,7 +15,8 @@ if (importmap_path = Rails.root.join("config/importmap.rb")).exist?
     after: "Rails.application.config.importmap.draw do\n"
 else
   say <<~INSTRUCTIONS, :red
-    You must add @hotwire/turbo-rails to your importmap to reference them via ESM.
+    You must add @hotwired/turbo-rails to your importmap to reference them via ESM.
+    Example: pin "@hotwired/turbo-rails", to: "turbo.js"
   INSTRUCTIONS
 end
 


### PR DESCRIPTION
Hi I was trying out rails 7 and stumbled upon this :)