### PR TITLE
Remove duplicated conversion to dom_id

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -12,10 +12,9 @@ module Turbo::Streams::ActionHelper
   def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil)
     template = action.to_sym == :remove ? "" : "<template>#{template}</template>"
 
-    if target
-      target = convert_to_turbo_stream_dom_id(target)
+    if target = convert_to_turbo_stream_dom_id(target)
       %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
-    elsif targets
+    elsif targets = convert_to_turbo_stream_dom_id(targets)
       %(<turbo-stream action="#{action}" targets="#{targets}">#{template}</turbo-stream>).html_safe
     else
       raise ArgumentError, "target or targets must be supplied"

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -212,29 +212,19 @@ class Turbo::Streams::TagBuilder
 
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
   def action(name, target, content = nil, allow_inferred_rendering: true, **rendering, &block)
-    target_name = extract_target_name_from(target)
     template = render_template(target, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
-    turbo_stream_action_tag name, target: target_name, template: template
+    turbo_stream_action_tag name, target: target, template: template
   end
 
   # Send an action of the type <tt>name</tt> to <tt>targets</tt>. Options described in the concrete methods.
   def action_all(name, targets, content = nil, allow_inferred_rendering: true, **rendering, &block)
-    targets_name = extract_target_name_from(targets)
     template = render_template(targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
-    turbo_stream_action_tag name, targets: targets_name, template: template
+    turbo_stream_action_tag name, targets: targets, template: template
   end
 
   private
-    def extract_target_name_from(target)
-      if target.respond_to?(:to_key)
-        ActionView::RecordIdentifier.dom_id(target)
-      else
-        target
-      end
-    end
-
     def render_template(target, content = nil, allow_inferred_rendering: true, **rendering, &block)
       case
       when content


### PR DESCRIPTION
The conversion of a target to a dom_id using `ActionView::RecordIdentifier.dom_id(target)` was performed both in `app/models/turbo/streams/tag_builder.rb` and in `app/helpers/turbo/streams/action_helper.rb` which was confusing.

This PR removes the duplication.