### PR TITLE
Document the rails turbo:install:redis rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The JavaScript for Turbo can either be run through the asset pipeline, which is 
 1. Add the `turbo-rails` gem to your Gemfile: `gem 'turbo-rails'`
 2. Run `./bin/bundle install`
 3. Run `./bin/rails turbo:install`
-4. Run `./bin/rails turbo:install:redis` to change the development ActionCable adapter from Async (the default one) to Redis. The Async adapter does not support broadcasting changes from the rails console to your browser.
+4. Run `./bin/rails turbo:install:redis` to change the development Action Cable adapter from Async (the default one) to Redis. The Async adapter does not support Turbo Stream broadcasting.
 
 Running `turbo:install` will install through NPM if Webpacker is installed in the application. Otherwise the asset pipeline version is used. To use the asset pipeline version, you must have `importmap-rails` installed first and listed higher in the Gemfile.
 


### PR DESCRIPTION
Broadcasting from the console to the browser is not possible with the default ActionCable Async adapter. 
The installation guide should document the existance of the `rails turbo:install:redis` rake task and mention the limitations of the Async adapter.