### PR TITLE
Switch on Redis if available on turbo:install

### DIFF
--- a/lib/install/turbo_with_asset_pipeline.rb
+++ b/lib/install/turbo_with_asset_pipeline.rb
@@ -19,5 +19,3 @@ else
     Example: pin "@hotwired/turbo-rails", to: "turbo.js"
   INSTRUCTIONS
 end
-
-say "Run turbo:install:redis to switch on Redis and use it in development for turbo streams", :red

--- a/lib/install/turbo_with_webpacker.rb
+++ b/lib/install/turbo_with_webpacker.rb
@@ -3,5 +3,3 @@ append_to_file "#{Webpacker.config.source_entry_path}/application.js", %(\nimpor
 
 say "Install Turbo"
 run "yarn add @hotwired/turbo-rails"
-
-say "Run turbo:install:redis to switch on Redis and use it in development for turbo streams"

--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -1,4 +1,18 @@
-def run_turbo_install_template(path) system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}" end
+def run_turbo_install_template(path)
+  system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
+end
+
+def redis_installed?
+  system('which redis-server')
+end
+
+def switch_on_redis_if_available
+  if redis_installed?
+    Rake::Task["turbo:install:redis"].invoke
+  else
+    puts "Run turbo:install:redis to switch on Redis and use it in development for turbo streams"
+  end
+end
 
 namespace :turbo do
   desc "Install Turbo into the app"
@@ -14,11 +28,13 @@ namespace :turbo do
     desc "Install Turbo into the app with asset pipeline"
     task :asset_pipeline do
       run_turbo_install_template "turbo_with_asset_pipeline"
+      switch_on_redis_if_available
     end
 
     desc "Install Turbo into the app with webpacker"
     task :webpacker do
       run_turbo_install_template "turbo_with_webpacker"
+      switch_on_redis_if_available
     end
 
     desc "Switch on Redis and use it in development"


### PR DESCRIPTION
It checks (naively) if Redis is installed, in case affirmative it run `turbo:install:redis`, otherwise print some information about how to do it.

Closes https://github.com/hotwired/turbo-rails/issues/225