### PR TITLE
Include `#` prefix in `[targets]`

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -14,7 +14,7 @@ module Turbo::Streams::ActionHelper
 
     if target = convert_to_turbo_stream_dom_id(target)
       %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
-    elsif targets = convert_to_turbo_stream_dom_id(targets)
+    elsif targets = convert_to_turbo_stream_dom_id(targets, include_selector: true)
       %(<turbo-stream action="#{action}" targets="#{targets}">#{template}</turbo-stream>).html_safe
     else
       raise ArgumentError, "target or targets must be supplied"
@@ -22,7 +22,11 @@ module Turbo::Streams::ActionHelper
   end
 
   private
-    def convert_to_turbo_stream_dom_id(target)
-      target.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(target) : target
+    def convert_to_turbo_stream_dom_id(target, include_selector: false)
+      if target.respond_to?(:to_key)
+        [ ("#" if include_selector), ActionView::RecordIdentifier.dom_id(target) ].compact.join
+      else
+        target
+      end
     end
 end

--- a/test/dummy/app/views/messages/update.turbo_stream.erb
+++ b/test/dummy/app/views/messages/update.turbo_stream.erb
@@ -1,9 +1,9 @@
 <%= turbo_stream.remove_all @message %>
 <%= turbo_stream.replace_all @message %>
 <%= turbo_stream.replace_all @message, "Something else" %>
-<%= turbo_stream.replace_all "message_5", "Something fifth" %>
-<%= turbo_stream.replace_all "message_5", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
-<%= turbo_stream.append_all "messages", @message %>
-<%= turbo_stream.append_all "messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
-<%= turbo_stream.prepend_all "messages", @message %>
-<%= turbo_stream.prepend_all "messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.replace_all "#message_5", "Something fifth" %>
+<%= turbo_stream.replace_all "#message_5", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.append_all "#messages", @message %>
+<%= turbo_stream.append_all "#messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.prepend_all "#messages", @message %>
+<%= turbo_stream.prepend_all "#messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -14,7 +14,7 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
 
   test "show all turbo actions" do
     get message_path(id: 1), as: :turbo_stream
-    assert_dom_equal <<~STREAM, @response.body
+    assert_dom_equal <<~HTML, @response.body
       <turbo-stream action="remove" target="message_1"></turbo-stream>
       <turbo-stream action="replace" target="message_1"><template><p>My message</p></template></turbo-stream>
       <turbo-stream action="replace" target="message_1"><template>Something else</template></turbo-stream>
@@ -24,31 +24,31 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
       <turbo-stream action="append" target="messages"><template><p>OLLA!</p></template></turbo-stream>
       <turbo-stream action="prepend" target="messages"><template><p>My message</p></template></turbo-stream>
       <turbo-stream action="prepend" target="messages"><template><p>OLLA!</p></template></turbo-stream>
-    STREAM
+    HTML
   end
 
   test "update all turbo actions for multiple targets" do
     patch message_path(id: 1), as: :turbo_stream
-    assert_dom_equal <<~STREAM, @response.body
-      <turbo-stream action="remove" targets="message_1"></turbo-stream>
-      <turbo-stream action="replace" targets="message_1"><template><p>My message</p></template></turbo-stream>
-      <turbo-stream action="replace" targets="message_1"><template>Something else</template></turbo-stream>
-      <turbo-stream action="replace" targets="message_5"><template>Something fifth</template></turbo-stream>
-      <turbo-stream action="replace" targets="message_5"><template><p>OLLA!</p></template></turbo-stream>
-      <turbo-stream action="append" targets="messages"><template><p>My message</p></template></turbo-stream>
-      <turbo-stream action="append" targets="messages"><template><p>OLLA!</p></template></turbo-stream>
-      <turbo-stream action="prepend" targets="messages"><template><p>My message</p></template></turbo-stream>
-      <turbo-stream action="prepend" targets="messages"><template><p>OLLA!</p></template></turbo-stream>
-    STREAM
+    assert_dom_equal <<~HTML, @response.body
+      <turbo-stream action="remove" targets="#message_1"></turbo-stream>
+      <turbo-stream action="replace" targets="#message_1"><template><p>My message</p></template></turbo-stream>
+      <turbo-stream action="replace" targets="#message_1"><template>Something else</template></turbo-stream>
+      <turbo-stream action="replace" targets="#message_5"><template>Something fifth</template></turbo-stream>
+      <turbo-stream action="replace" targets="#message_5"><template><p>OLLA!</p></template></turbo-stream>
+      <turbo-stream action="append" targets="#messages"><template><p>My message</p></template></turbo-stream>
+      <turbo-stream action="append" targets="#messages"><template><p>OLLA!</p></template></turbo-stream>
+      <turbo-stream action="prepend" targets="#messages"><template><p>My message</p></template></turbo-stream>
+      <turbo-stream action="prepend" targets="#messages"><template><p>OLLA!</p></template></turbo-stream>
+    HTML
   end
 
   test "includes html format when rendering turbo_stream actions" do
     post posts_path, as: :turbo_stream
-    assert_dom_equal <<~STREAM.chomp, @response.body
+    assert_dom_equal <<~HTML.chomp, @response.body
       <turbo-stream action="update" target="form-area"><template>
         Form
       </template></turbo-stream>
-    STREAM
+    HTML
   end
 
   test "render correct partial for namespaced models" do


### PR DESCRIPTION
Since `<turbo-stream targets="...">` values are CSS selectors and _not_
element identifiers, mapping a collection of elements that integrate
with `dom_id` results in unresolvable selectors.

For example, passing an array of `Message` instances:

```ruby
messages = [ 1, 2, 3 ].map { |id| Message.new(id: id) }

turbo_stream.replace_all messages #=> <turbo-stream targets="message_1 message_2 message_3">...</turbo-stream>
```

When mapping a collection of targets that respond to `to_key` and
integrate with `dom_id`, map each value and prefix it with the [ID
selector][].

As a result, the `[targets]` attribute will be a space-separated list of
valid ID selectors:

```ruby
messages = [ 1, 2, 3 ].map { |id| Message.new(id: id) }

turbo_stream.replace_all messages #=> <turbo-stream targets="#message_1 #message_2 #message_3">...</turbo-stream>
```

[ID selector]: https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors