### PR TITLE
Dummy app: Depend on `turbo-rails` through importmap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem 'rake'
 gem 'byebug'
 gem 'puma'
 
+group :development, :test do
+  gem 'importmap-rails'
+end
+
 group :test do
   gem 'capybara'
   gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    importmap-rails (0.5.1)
+      rails (>= 6.0.0)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -168,6 +170,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara
+  importmap-rails
   puma
   rake
   rexml

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_tree ../../javascript .js

--- a/test/dummy/app/javascript/application.js
+++ b/test/dummy/app/javascript/application.js
@@ -1,1 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"

--- a/test/dummy/app/javascript/application.js
+++ b/test/dummy/app/javascript/application.js
@@ -1,0 +1,1 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= yield :head %>
-    <%= javascript_include_tag "turbo", type: "module" %>
     <%= javascript_importmap_tags %>
   </head>
 

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= yield :head %>
     <%= javascript_include_tag "turbo", type: "module" %>
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/test/dummy/bin/importmap
+++ b/test/dummy/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -1,0 +1,6 @@
+# Use direct uploads for Active Storage (remember to import "@rails/activestorage" in your application.js)
+# pin "@rails/activestorage", to: "activestorage.esm.js"
+
+# Use node modules from a JavaScript CDN by running ./bin/importmap
+
+pin "application"

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -5,3 +5,4 @@
 
 pin "application"
 pin "@hotwired/turbo-rails", to: "turbo.js"
+pin "@rails/actioncable", to: "actioncable.esm.js"

--- a/test/dummy/config/importmap.rb
+++ b/test/dummy/config/importmap.rb
@@ -4,3 +4,4 @@
 # Use node modules from a JavaScript CDN by running ./bin/importmap
 
 pin "application"
+pin "@hotwired/turbo-rails", to: "turbo.js"


### PR DESCRIPTION
Depend on `importmap-rails` in dummy app
===

When running tests against a dummy Rails application, use
[importmap-rails][].

The contents of this commit were generated by following the
[Installation][] instructions.

[importmap-rails]: https://github.com/rails/importmap-rails/tree/v0.5.1
[Installation]: https://github.com/rails/importmap-rails/tree/v0.5.1#installation

Depend on `turbo-rails` through importmap
===

The contents of this commit were generated by following the
[Installation](./README.md#installation) instructions.

Depend on `@rails/actioncable` through importmap
===

Replace the `package.json` development dependency with an importmap
entry.

Remove Webpacker JavaScript entrypoints
===

Removes Webpacker-specific helpers from the Application layout in favor
of the importmap-generated helpers.
