### PR TITLE
Fixes uncommenting of redis gem when using turbo:install:redis

### DIFF
--- a/lib/install/turbo_needs_redis.rb
+++ b/lib/install/turbo_needs_redis.rb
@@ -1,6 +1,6 @@
 if (cable_config_path = Rails.root.join("config/cable.yml")).exist?
   say "Enable redis in bundle"
-  uncomment_lines "Gemfile", %(gem 'redis')
+  uncomment_lines "Gemfile", /gem ['"]redis['"]/
 
   say "Switch development cable to use redis"
   gsub_file cable_config_path.to_s, /development:\n\s+adapter: async/, "development:\n  adapter: redis\n  url: redis://localhost:6379/1"


### PR DESCRIPTION
Currently, the `rails turbo:install:redis` task tries to uncomment the `redis` gem but fails if the Gemfile uses double quotes (rather than single ones). The default Gemfile provided in a new Rails 7 app uses double quotes.

This PR addresses that by using a regexp to match both types of quote.