### PR TITLE
Added turbo_frame_id method to return "Turbo-Frame" header value

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -19,6 +19,10 @@ module Turbo::Frames::FrameRequest
 
   private
     def turbo_frame_request?
-      request.headers["Turbo-Frame"].present?
+      turbo_frame_id.present?
+    end
+
+    def turbo_frame_id
+      request.headers["Turbo-Frame"]
     end
 end

--- a/test/dummy/app/controllers/trays_controller.rb
+++ b/test/dummy/app/controllers/trays_controller.rb
@@ -1,5 +1,6 @@
 class TraysController < ApplicationController
   def show
+    @frame_id = turbo_frame_id
   end
 
   def create

--- a/test/dummy/app/views/trays/show.html.erb
+++ b/test/dummy/app/views/trays/show.html.erb
@@ -1,3 +1,4 @@
 <turbo-frame id="tray">
   <div>This is a tray!</div>
+  <div><%= @frame_id %></div>
 </turbo-frame>

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -18,4 +18,14 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_equal etag_with_frame, etag_without_frame
   end
+
+  test "turbo_frame_id returns the Turbo-Frame header value" do
+    turbo_frame_id = "test_frame_id"
+
+    get tray_path(id: 1)
+    assert_no_match /#{turbo_frame_id}/, @response.body
+
+    get tray_path(id: 1), headers: { "Turbo-Frame" => turbo_frame_id }
+    assert_match /#{turbo_frame_id}/, @response.body
+  end
 end


### PR DESCRIPTION
Shortcut when in need for the id of the requesting turbo frame.
We use it in our default error handling to generate an appropriate turbo_frame tag, which will display the error.