### PR TITLE
Suppress warnings with `ruby -w`

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -6,61 +6,61 @@ module Turbo::Streams::Broadcasts
   include Turbo::Streams::ActionHelper
 
   def broadcast_remove_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :remove, **opts
+    broadcast_action_to(*streamables, action: :remove, **opts)
   end
 
   def broadcast_replace_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :replace, **opts
+    broadcast_action_to(*streamables, action: :replace, **opts)
   end
 
   def broadcast_update_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :update, **opts
+    broadcast_action_to(*streamables, action: :update, **opts)
   end
 
   def broadcast_before_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :before, **opts
+    broadcast_action_to(*streamables, action: :before, **opts)
   end
 
   def broadcast_after_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :after, **opts
+    broadcast_action_to(*streamables, action: :after, **opts)
   end
 
   def broadcast_append_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :append, **opts
+    broadcast_action_to(*streamables, action: :append, **opts)
   end
 
   def broadcast_prepend_to(*streamables, **opts)
-    broadcast_action_to *streamables, action: :prepend, **opts
+    broadcast_action_to(*streamables, action: :prepend, **opts)
   end
 
   def broadcast_action_to(*streamables, action:, target: nil, targets: nil, **rendering)
-    broadcast_stream_to *streamables, content: turbo_stream_action_tag(action, target: target, targets: targets, template:
+    broadcast_stream_to(*streamables, content: turbo_stream_action_tag(action, target: target, targets: targets, template:
       rendering.delete(:content) || (rendering.any? ? render_format(:html, **rendering) : nil)
-    )
+    ))
   end
 
   def broadcast_replace_later_to(*streamables, **opts)
-    broadcast_action_later_to *streamables, action: :replace, **opts
+    broadcast_action_later_to(*streamables, action: :replace, **opts)
   end
 
   def broadcast_update_later_to(*streamables, **opts)
-    broadcast_action_later_to *streamables, action: :update, **opts
+    broadcast_action_later_to(*streamables, action: :update, **opts)
   end
 
   def broadcast_before_later_to(*streamables, **opts)
-    broadcast_action_later_to *streamables, action: :before, **opts
+    broadcast_action_later_to(*streamables, action: :before, **opts)
   end
 
   def broadcast_after_later_to(*streamables, **opts)
-    broadcast_action_later_to *streamables, action: :after, **opts
+    broadcast_action_later_to(*streamables, action: :after, **opts)
   end
 
   def broadcast_append_later_to(*streamables, **opts)
-    broadcast_action_later_to *streamables, action: :append, **opts
+    broadcast_action_later_to(*streamables, action: :append, **opts)
   end
 
   def broadcast_prepend_later_to(*streamables, **opts)
-    broadcast_action_later_to *streamables, action: :prepend, **opts
+    broadcast_action_later_to(*streamables, action: :prepend, **opts)
   end
 
   def broadcast_action_later_to(*streamables, action:, target: nil, targets: nil, **rendering)
@@ -69,7 +69,7 @@ module Turbo::Streams::Broadcasts
   end
 
   def broadcast_render_to(*streamables, **rendering)
-    broadcast_stream_to *streamables, content: render_format(:turbo_stream, **rendering)
+    broadcast_stream_to(*streamables, content: render_format(:turbo_stream, **rendering))
   end
 
   def broadcast_render_later_to(*streamables, **rendering)

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -76,7 +76,7 @@ module Turbo::Broadcastable
   #   # Sends <turbo-stream action="remove" target="clearance_5"></turbo-stream> to the stream named "identity:2:clearances"
   #   clearance.broadcast_remove_to examiner.identity, :clearances
   def broadcast_remove_to(*streamables, target: self)
-    Turbo::StreamsChannel.broadcast_remove_to *streamables, target: target
+    Turbo::StreamsChannel.broadcast_remove_to(*streamables, target: target)
   end
 
   # Same as <tt>#broadcast_remove_to</tt>, but the designated stream is automatically set to the current model.
@@ -95,7 +95,7 @@ module Turbo::Broadcastable
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_replace_to examiner.identity, :clearances, partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_replace_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_replace_to *streamables, target: self, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_replace_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_replace_to</tt>, but the designated stream is automatically set to the current model.
@@ -114,7 +114,7 @@ module Turbo::Broadcastable
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_update_to examiner.identity, :clearances, partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_update_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_update_to *streamables, target: self, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_update_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_update_to</tt>, but the designated stream is automatically set to the current model.
@@ -135,7 +135,7 @@ module Turbo::Broadcastable
   #   clearance.broadcast_before_to examiner.identity, :clearances, target: "clearance_5",
   #     partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_before_to(*streamables, target:, **rendering)
-    Turbo::StreamsChannel.broadcast_before_to *streamables, target: target, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_before_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Insert a rendering of this broadcastable model after the target identified by it's dom id passed as <tt>target</tt>
@@ -151,7 +151,7 @@ module Turbo::Broadcastable
   #   clearance.broadcast_after_to examiner.identity, :clearances, target: "clearance_5",
   #     partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_after_to(*streamables, target:, **rendering)
-    Turbo::StreamsChannel.broadcast_after_to *streamables, target: target, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_after_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Append a rendering of this broadcastable model to the target identified by it's dom id passed as <tt>target</tt>
@@ -167,7 +167,7 @@ module Turbo::Broadcastable
   #   clearance.broadcast_append_to examiner.identity, :clearances, target: "clearances",
   #     partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_append_to(*streamables, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_append_to *streamables, target: target, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_append_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_append_to</tt>, but the designated stream is automatically set to the current model.
@@ -188,7 +188,7 @@ module Turbo::Broadcastable
   #   clearance.broadcast_prepend_to examiner.identity, :clearances, target: "clearances",
   #     partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_prepend_to(*streamables, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_prepend_to *streamables, target: target, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_prepend_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_prepend_to</tt>, but the designated stream is automatically set to the current model.
@@ -213,7 +213,7 @@ module Turbo::Broadcastable
 
   # Same as <tt>broadcast_replace_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_replace_later_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_replace_later_to *streamables, target: self, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_replace_later_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_replace_later_to</tt>, but the designated stream is automatically set to the current model.
@@ -223,7 +223,7 @@ module Turbo::Broadcastable
 
   # Same as <tt>broadcast_update_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_update_later_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_update_later_to *streamables, target: self, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_update_later_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_update_later_to</tt>, but the designated stream is automatically set to the current model.
@@ -233,7 +233,7 @@ module Turbo::Broadcastable
 
   # Same as <tt>broadcast_append_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_append_later_to(*streamables, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_append_later_to *streamables, target: target, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_append_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_append_later_to</tt>, but the designated stream is automatically set to the current model.
@@ -243,7 +243,7 @@ module Turbo::Broadcastable
 
   # Same as <tt>broadcast_prepend_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_prepend_later_to(*streamables, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_prepend_later_to *streamables, target: target, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_prepend_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_prepend_later_to</tt>, but the designated stream is automatically set to the current model.
@@ -283,7 +283,7 @@ module Turbo::Broadcastable
   # Same as <tt>broadcast_render_later</tt> but run with the added option of naming the stream using the passed
   # <tt>streamables</tt>.
   def broadcast_render_later_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_render_later_to *streamables, **broadcast_rendering_with_defaults(rendering)
+    Turbo::StreamsChannel.broadcast_render_later_to(*streamables, **broadcast_rendering_with_defaults(rendering))
   end
 
 

--- a/test/drive/drive_helper_test.rb
+++ b/test/drive/drive_helper_test.rb
@@ -3,6 +3,6 @@ require "turbo_test"
 class Turbo::DriveHelperTest < ActionDispatch::IntegrationTest
   test "opting out of the default cache" do
     get trays_path
-    assert_match /<meta name="turbo-cache-control" content="no-cache">/, @response.body
+    assert_match(/<meta name="turbo-cache-control" content="no-cache">/, @response.body)
   end
 end


### PR DESCRIPTION
I got the following warnings from turbo-rails when I tried Rails 7.0.0.alpha2.

```
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:79: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:98: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:117: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:138: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:154: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:170: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:191: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:216: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:226: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:236: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:246: warning: `*' interpreted as argument prefix
/path/to/gems/turbo-rails-0.7.12/app/models/concerns/turbo/broadcastable.rb:286: warning: `*' interpreted as argument prefix
```

This patch suppresses the warnings and others which I found in this
repository with `ls **/*.rb | xargs -n1 ruby -cw`. Now the command
displays "Syntax OK" only.