### PR TITLE
Send which output to /dev/null

### DIFF
--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -1,9 +1,9 @@
 def run_turbo_install_template(path)
-  system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb",  __dir__)}"
+  system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{path}.rb", __dir__)}"
 end
 
 def redis_installed?
-  system('which redis-server')
+  system('which redis-server > /dev/null')
 end
 
 def switch_on_redis_if_available


### PR DESCRIPTION
It avoids noise on the installer's output.

I added it with https://github.com/hotwired/turbo-rails/pull/226. I feel uncomfortable when I see the unnecessary message on the installer's output.

Before
<img width="278" alt="Screenshot 2021-09-21 at 23 32 15" src="https://user-images.githubusercontent.com/16633/134251221-c478f71e-a0bb-4994-9a10-b4d11de9bd82.png">

After
<img width="285" alt="Screenshot 2021-09-21 at 23 32 27" src="https://user-images.githubusercontent.com/16633/134251246-1fa917f1-c80a-4419-a5e9-0041c5b5afc6.png">

