### PR TITLE
Add Redis gem if it is not present on the Gemfile

### DIFF
--- a/lib/install/turbo_needs_redis.rb
+++ b/lib/install/turbo_needs_redis.rb
@@ -1,6 +1,15 @@
 if (cable_config_path = Rails.root.join("config/cable.yml")).exist?
   say "Enable redis in bundle"
-  uncomment_lines "Gemfile", /gem ['"]redis['"]/
+
+  gemfile_content = File.read(Rails.root.join("Gemfile"))
+  pattern = /gem ['"]redis['"]/
+
+  if gemfile_content.match?(pattern)
+    uncomment_lines "Gemfile", pattern
+  else
+    gem 'redis', '~> 4.0', comment: "Use Redis as Action Cable adapter instead of default Async. The Async adapter\ndoes not support Turbo Stream broadcasting."
+  end
+
   run_bundle
 
   say "Switch development cable to use redis"


### PR DESCRIPTION
turbo:install:redis task adds the Redis gem to the Gemfile if it is not present.
Otherwise, it tries to uncomment it as before.