### PR TITLE
Broadcast HTML from Model

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -27,7 +27,7 @@
 # (which is derived by default from the plural model name of the model, but can be overwritten).
 #
 # You can also choose to render html instead of a partial inside of a broadcast
-# you do this by passing an html: option to any broadcast method that accepts **rendering options
+# you do this by passing the html: option to any broadcast method that accepts the **rendering argument
 # 
 #   class Message < ApplicationRecord
 #     belongs_to :user

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -296,9 +296,13 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        return if o[:html].present? # Allows html to be passed in instead of partial
-        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
-        o[:partial] ||= to_partial_path
+        if o[:html].present? 
+          # Allows html to be passed in instead of partial
+          o[:html] = o[:html]
+        else
+          o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
+          o[:partial] ||= to_partial_path
+        end
       end
     end
 end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -310,7 +310,7 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        # Dont Override HTML and Inline options by :partial
+        # if the html or inline options are passed it will skip setting a partial from #to_partial_path
         unless o.include?(:html) || o.include?(:inline)
           o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
           o[:partial] ||= to_partial_path

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -310,9 +310,9 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
+        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
         # if the html or inline options are passed it will skip setting a partial from #to_partial_path
         unless o.include?(:html) || o.include?(:inline)
-          o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
           o[:partial] ||= to_partial_path
         end
       end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -26,6 +26,20 @@
 # and finally prepend the result of that partial rendering to the target identified with the dom id "clearances"
 # (which is derived by default from the plural model name of the model, but can be overwritten).
 #
+# You can also choose to render html or inline erb instead of a partial inside of a broadcast
+# you do this by passing an html: option or inline: to any broadcast method that accepts **rendering options
+# 
+#   class Message < ApplicationRecord
+#     belongs_to :user
+#
+#     after_create_commit :update_message_count
+#
+#     private
+#       def update_message_count
+#         broadcast_update_to(user, :message_count, html: "<p> #{user.messages.count} </p>")
+#       end
+#   end
+# 
 # There are four basic actions you can broadcast: <tt>remove</tt>, <tt>replace</tt>, <tt>append</tt>, and
 # <tt>prepend</tt>. As a rule, you should use the <tt>_later</tt> versions of everything except for remove when broadcasting
 # within a real-time path, like a controller or model, since all those updates require a rendering step, which can slow down

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -296,10 +296,8 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        if o[:html].present? 
-          # Allows html to be passed in instead of partial
-          o[:html] = o[:html]
-        else
+        # Dont Override HTML and Inline options by :partial
+        unless o.include?(:html) || o.include?(:inline)
           o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
           o[:partial] ||= to_partial_path
         end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -26,8 +26,8 @@
 # and finally prepend the result of that partial rendering to the target identified with the dom id "clearances"
 # (which is derived by default from the plural model name of the model, but can be overwritten).
 #
-# You can also choose to render html or inline erb instead of a partial inside of a broadcast
-# you do this by passing an html: option or inline: to any broadcast method that accepts **rendering options
+# You can also choose to render html instead of a partial inside of a broadcast
+# you do this by passing an html: option to any broadcast method that accepts **rendering options
 # 
 #   class Message < ApplicationRecord
 #     belongs_to :user
@@ -311,8 +311,8 @@ module Turbo::Broadcastable
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
         o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
-        # if the html or inline options are passed it will skip setting a partial from #to_partial_path
-        unless o.include?(:html) || o.include?(:inline)
+        # if the html option is passed in it will skip setting a partial from #to_partial_path
+        unless o.include?(:html)
           o[:partial] ||= to_partial_path
         end
       end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -36,7 +36,7 @@
 #
 #     private
 #       def update_message_count
-#         broadcast_update_to(user, :message_count, html: "<p> #{user.messages.count} </p>")
+#         broadcast_update_to(user, :messages, target: "message-count" html: "<p> #{user.messages.count} </p>")
 #       end
 #   end
 # 

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -296,6 +296,7 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
+        return if o[:html].present? # Allows html to be passed in instead of partial
         o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
         o[:partial] ||= to_partial_path
       end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -36,7 +36,7 @@
 #
 #     private
 #       def update_message_count
-#         broadcast_update_to(user, :messages, target: "message-count" html: "<p> #{user.messages.count} </p>")
+#         broadcast_update_to(user, :messages, target: "message-count", html: "<p> #{user.messages.count} </p>")
 #       end
 #   end
 # 

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -3,6 +3,10 @@ class MessagesController < ApplicationController
     @message = Message.new(id: 1, content: "My message")
   end
 
+  def index
+    @messages = Message.all
+  end
+
   def create
     respond_to do |format|
       format.html { redirect_to message_url(id: 1) }

--- a/test/dummy/app/views/messages/index.html.erb
+++ b/test/dummy/app/views/messages/index.html.erb
@@ -4,6 +4,9 @@
   <%= @messages.count %> messages sent
 </span>
 
+<span id="message-history">
+</span>
+
 <%= turbo_stream_from "messages" %>
 <div id="messages">
 </div>

--- a/test/dummy/app/views/messages/index.html.erb
+++ b/test/dummy/app/views/messages/index.html.erb
@@ -1,4 +1,9 @@
 <h1>Messages</h1>
 
+<span id="messages-count">
+  <%= @messages.count %> messages sent
+</span>
+
 <%= turbo_stream_from "messages" %>
-<div id="messages"></div>
+<div id="messages">
+</div>

--- a/test/dummy/app/views/messages/index.html.erb
+++ b/test/dummy/app/views/messages/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Messages</h1>
 
-<span id="messages-count">
+<span id="message-count">
   <%= @messages.count %> messages sent
 </span>
 

--- a/test/dummy/app/views/messages/index.html.erb
+++ b/test/dummy/app/views/messages/index.html.erb
@@ -4,9 +4,6 @@
   <%= @messages.count %> messages sent
 </span>
 
-<span id="message-history">
-</span>
-
 <%= turbo_stream_from "messages" %>
 <div id="messages">
 </div>

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -32,7 +32,7 @@ class BroadcastsTest < ApplicationSystemTestCase
     
     message.broadcast_update_to :messages, target: "message-history", 
       inline: <<~ERB 
-      <% Message.all.each do |message| %> 
+      <% Message.order(created_at: :desc).first(3).each do |message| %> 
         <%= message.content %> 
       <% end %>
     ERB

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -29,8 +29,9 @@ class BroadcastsTest < ApplicationSystemTestCase
     visit messages_path
     
     message = Message.new(record_id: 1, content: "Message with inline")
-    message.broadcast_update_to :messages, target: "messages-count", 
-      inline: ERB.new("<%= Message.count %> messages sent").result
+    message.broadcast_update_to :messages, target: "messages-count", inline: <<~ERB
+      <%= Message.count %> messages sent
+    ERB
 
     assert_selector "#messages-count", text: "#{Message.count} messages sent", wait: 10
   end

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -17,8 +17,6 @@ class BroadcastsTest < ApplicationSystemTestCase
 
     assert_text "Messages"
     message = Message.create(content: "A new message")
-    message.broadcast_append_to(:messages)
-    assert_text("A new message")
     
     message.broadcast_update_to(:messages, target: "messages-count", 
       html: "#{Message.count} messages sent")
@@ -30,14 +28,12 @@ class BroadcastsTest < ApplicationSystemTestCase
     
     message = Message.create(content: "Message with inline")
     
-    message.broadcast_update_to :messages, target: "message-history", 
+    message.broadcast_update_to :messages, target: "messages-count", 
       inline: <<~ERB 
-      <% Message.order(created_at: :desc).first(3).each do |message| %> 
-        <%= message.content %> 
-      <% end %>
+      <%= Message.count %> messages sent
     ERB
 
-    assert_selector "#message-history", text: message.content, wait: 10
+    assert_selector "#messages-count", text: Message.count, wait: 10
   end
 
   test "Users::Profile broadcasts Turbo Streams" do

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -25,6 +25,16 @@ class BroadcastsTest < ApplicationSystemTestCase
     assert_selector("#messages-count", text: Message.count, wait: 10)
   end
 
+  test "New messages update the message count with inline: content" do
+    visit messages_path
+    
+    message = Message.new(record_id: 1, content: "Message with inline")
+    message.broadcast_update_to :messages, target: "messages-count", 
+      inline: ERB.new("<%= Message.count %> messages sent").result
+
+    assert_selector "#messages-count", text: "#{Message.count} messages sent", wait: 10
+  end
+
   test "Users::Profile broadcasts Turbo Streams" do
     visit users_profiles_path
 

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -18,9 +18,9 @@ class BroadcastsTest < ApplicationSystemTestCase
     assert_text "Messages"
     message = Message.create(content: "A new message")
     
-    message.broadcast_update_to(:messages, target: "messages-count", 
+    message.broadcast_update_to(:messages, target: "message-count", 
       html: "#{Message.count} messages sent")
-    assert_selector("#messages-count", text: Message.count, wait: 10)
+    assert_selector("#message-count", text: Message.count, wait: 10)
   end
 
   test "New messages update the message count with inline: content" do
@@ -28,12 +28,12 @@ class BroadcastsTest < ApplicationSystemTestCase
     
     message = Message.create(content: "Message with inline")
     
-    message.broadcast_update_to :messages, target: "messages-count", 
+    message.broadcast_update_to :messages, target: "message-count", 
       inline: <<~ERB 
       <%= Message.count %> messages sent
     ERB
 
-    assert_selector "#messages-count", text: Message.count, wait: 10
+    assert_selector "#message-count", text: Message.count, wait: 10
   end
 
   test "Users::Profile broadcasts Turbo Streams" do

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -16,7 +16,7 @@ class BroadcastsTest < ApplicationSystemTestCase
     visit messages_path
 
     assert_text "Messages"
-    message = Message.new(record_id: 1, content: "A new message")
+    message = Message.create(content: "A new message")
     message.broadcast_append_to(:messages)
     assert_text("A new message")
     
@@ -28,7 +28,7 @@ class BroadcastsTest < ApplicationSystemTestCase
   test "New messages update the message count with inline: content" do
     visit messages_path
     
-    message = Message.new(record_id: 1, content: "Message with inline")
+    message = Message.create(content: "Message with inline")
     
     message.broadcast_update_to :messages, target: "message-history", 
       inline: <<~ERB 

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -12,6 +12,17 @@ class BroadcastsTest < ApplicationSystemTestCase
     end
   end
 
+  test "New messages update the message count with html" do
+    visit messages_path
+
+    assert_text "Messages"
+    message = Message.new(record_id: 1, content: "A new message")
+    message.broadcast_append_to(:messages)
+    message.broadcast_update_to(:messages, target: "messages-count", 
+      html: "#{Message.count} messages sent")
+    assert_selector("#messages-count", text: Message.count, wait: 10)
+  end
+
   test "Users::Profile broadcasts Turbo Streams" do
     visit users_profiles_path
 

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -29,11 +29,15 @@ class BroadcastsTest < ApplicationSystemTestCase
     visit messages_path
     
     message = Message.new(record_id: 1, content: "Message with inline")
-    message.broadcast_update_to :messages, target: "messages-count", inline: <<~ERB
-      <%= Message.count %> messages sent
+    
+    message.broadcast_update_to :messages, target: "message-history", 
+      inline: <<~ERB 
+      <% Message.all.each do |message| %> 
+        <%= message.content %> 
+      <% end %>
     ERB
 
-    assert_selector "#messages-count", text: "#{Message.count} messages sent", wait: 10
+    assert_selector "#message-history", text: message.content, wait: 10
   end
 
   test "Users::Profile broadcasts Turbo Streams" do

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -23,19 +23,6 @@ class BroadcastsTest < ApplicationSystemTestCase
     assert_selector("#message-count", text: Message.count, wait: 10)
   end
 
-  test "New messages update the message count with inline: content" do
-    visit messages_path
-    
-    message = Message.create(content: "Message with inline")
-    
-    message.broadcast_update_to :messages, target: "message-count", 
-      inline: <<~ERB 
-      <%= Message.count %> messages sent
-    ERB
-
-    assert_selector "#message-count", text: Message.count, wait: 10
-  end
-
   test "Users::Profile broadcasts Turbo Streams" do
     visit users_profiles_path
 

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -18,6 +18,8 @@ class BroadcastsTest < ApplicationSystemTestCase
     assert_text "Messages"
     message = Message.new(record_id: 1, content: "A new message")
     message.broadcast_append_to(:messages)
+    assert_text("A new message")
+    
     message.broadcast_update_to(:messages, target: "messages-count", 
       html: "#{Message.count} messages sent")
     assert_selector("#messages-count", text: Message.count, wait: 10)


### PR DESCRIPTION
Allows option to pass in html to broadcast from model
something like this will allow you to add html to a broadcast instead of a partial or otherwise automatically finding a partial with to_partial_path
`broadcast_replace_to(:feed, html: "<p> Random HTML </p>")`

Allows option to pass in html to broadcast from model this works with the **rendering methods included from the Turbo::Broadcastable module.