### PR TITLE
Add guard to fail CI on uncommitted changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,7 @@ jobs:
         run: |
           bin/rails db:test:prepare
           bin/test test/**/*_test.rb
+      - name: Fail when generated changes are not checked-in
+        run: |
+          git update-index --refresh
+          git diff-index --quiet HEAD --

--- a/bin/test
+++ b/bin/test
@@ -4,7 +4,10 @@ $: << File.expand_path("../test", __dir__)
 puts "Installing Ruby dependencies"
 `bundle install`
 
-puts "Installing JavasScript"
+puts "Installing JavaScript dependencies"
+`yarn install`
+
+puts "Building JavaScript"
 `yarn build`
 
 puts "Migrating test database"

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -1,6 +1,8 @@
 require "turbo_test"
 
 class Turbo::FramesHelperTest < ActionView::TestCase
+  setup { Message.delete_all }
+
   test "frame with src" do
     assert_dom_equal %(<turbo-frame src="/trays/1" id="tray"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1")
   end


### PR DESCRIPTION
When pushing to GitHub Actions, fail the test suite if executing
`bin/test` generates changes that are uncommitted.

Similarly, extend `bin/test` to also `yarn install` to ensure that
assets are not out of synchronization.
