### PR TITLE
Promote Dummy app's `Message` to Active Record

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -8,7 +8,7 @@ puts "Installing JavasScript"
 `yarn build`
 
 puts "Migrating test database"
-`cd test/dummy; RAILS_ENV=test ./bin/rails db:migrate`
+`cd test/dummy; RAILS_ENV=test ./bin/rails db:migrate db:test:prepare`
 
 require "bundler/setup"
 require "rails/plugin/test"

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -1,6 +1,6 @@
 class MessagesController < ApplicationController
   def show
-    @message = Message.new(record_id: 1, content: "My message")
+    @message = Message.new(id: 1, content: "My message")
   end
 
   def create
@@ -11,6 +11,6 @@ class MessagesController < ApplicationController
   end
 
   def update
-    @message = Message.new(record_id: 1, content: "My message")
+    @message = Message.new(id: 1, content: "My message")
   end
 end

--- a/test/dummy/app/models/message.rb
+++ b/test/dummy/app/models/message.rb
@@ -1,41 +1,5 @@
-class Message
-  include Turbo::Broadcastable
-
-  attr_reader :record_id, :content
-
-  def self.model_name
-    ActiveModel::Name.new(self)
-  end
-
-  def initialize(record_id:, content:)
-    @record_id, @content = record_id, content
-  end
-
-  def to_key
-    [ record_id ]
-  end
-
-  def to_param
-    record_id.to_s
-  end
-
-  def to_partial_path
-    "messages/message"
-  end
-
+class Message < ApplicationRecord
   def to_s
     content
-  end
-
-  def model_name
-    self.class.model_name
-  end
-
-  def to_model
-    self
-  end
-
-  def persisted?
-    true
   end
 end

--- a/test/dummy/app/views/messages/show.turbo_stream.erb
+++ b/test/dummy/app/views/messages/show.turbo_stream.erb
@@ -2,8 +2,8 @@
 <%= turbo_stream.replace @message %>
 <%= turbo_stream.replace @message, "Something else" %>
 <%= turbo_stream.replace "message_5", "Something fifth" %>
-<%= turbo_stream.replace "message_5", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.replace "message_5", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
 <%= turbo_stream.append "messages", @message %>
-<%= turbo_stream.append "messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.append "messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
 <%= turbo_stream.prepend "messages", @message %>
-<%= turbo_stream.prepend "messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.prepend "messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>

--- a/test/dummy/app/views/messages/update.turbo_stream.erb
+++ b/test/dummy/app/views/messages/update.turbo_stream.erb
@@ -2,8 +2,8 @@
 <%= turbo_stream.replace_all @message %>
 <%= turbo_stream.replace_all @message, "Something else" %>
 <%= turbo_stream.replace_all "#message_5", "Something fifth" %>
-<%= turbo_stream.replace_all "#message_5", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.replace_all "#message_5", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
 <%= turbo_stream.append_all "#messages", @message %>
-<%= turbo_stream.append_all "#messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.append_all "#messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
 <%= turbo_stream.prepend_all "#messages", @message %>
-<%= turbo_stream.prepend_all "#messages", partial: "messages/message", locals: { message: Message.new(record_id: 5, content: "OLLA!") } %>
+<%= turbo_stream.prepend_all "#messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>

--- a/test/dummy/db/migrate/20210923150403_create_messages.rb
+++ b/test/dummy/db/migrate/20210923150403_create_messages.rb
@@ -1,0 +1,9 @@
+class CreateMessages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :messages do |t|
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_08_163514) do
+ActiveRecord::Schema.define(version: 2021_09_23_150403) do
 
   create_table "articles", force: :cascade do |t|
     t.text "body", null: false
@@ -24,6 +24,12 @@ ActiveRecord::Schema.define(version: 2021_04_08_163514) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["article_id"], name: "index_comments_on_article_id"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "comments", "articles"

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -6,7 +6,7 @@ class Turbo::FramesHelperTest < ActionView::TestCase
   end
 
   test "frame with model src" do
-    record = Message.new(record_id: "1", content: "ignored")
+    record = Message.create(id: "1", content: "ignored")
 
     assert_dom_equal %(<turbo-frame src="/messages/1" id="message"></turbo-frame>), turbo_frame_tag("message", src: record)
   end
@@ -16,7 +16,7 @@ class Turbo::FramesHelperTest < ActionView::TestCase
   end
 
   test "frame with model argument" do
-    record = Message.new(record_id: "1", content: "ignored")
+    record = Message.new(id: "1", content: "ignored")
 
     assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
   end

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -4,7 +4,7 @@ require "action_cable"
 class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   include ActiveJob::TestHelper, Turbo::Streams::ActionHelper
 
-  setup { @message = Message.new(record_id: 1, content: "Hello!") }
+  setup { @message = Message.new(id: 1, content: "Hello!") }
 
   test "broadcasting remove to stream now" do
     assert_broadcast_on "stream", turbo_stream_action_tag("remove", target: "message_1") do
@@ -13,7 +13,7 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasting remove now" do
-    assert_broadcast_on @message.to_param, turbo_stream_action_tag("remove", target: "message_1") do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("remove", target: "message_1") do
       @message.broadcast_remove
     end
   end
@@ -25,7 +25,7 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasting replace now" do
-    assert_broadcast_on @message.to_param, turbo_stream_action_tag("replace", target: "message_1", template: "<p>Hello!</p>") do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("replace", target: "message_1", template: "<p>Hello!</p>") do
       @message.broadcast_replace
     end
   end
@@ -37,7 +37,7 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasting update now" do
-    assert_broadcast_on @message.to_param, turbo_stream_action_tag("update", target: "message_1", template: "<p>Hello!</p>") do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("update", target: "message_1", template: "<p>Hello!</p>") do
       @message.broadcast_update
     end
   end
@@ -67,7 +67,7 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasting append now" do
-    assert_broadcast_on @message.to_param, turbo_stream_action_tag("append", target: "messages", template: "<p>Hello!</p>") do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("append", target: "messages", template: "<p>Hello!</p>") do
       @message.broadcast_append
     end
   end
@@ -85,7 +85,7 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasting prepend now" do
-    assert_broadcast_on @message.to_param, turbo_stream_action_tag("prepend", target: "messages", template: "<p>Hello!</p>") do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: "<p>Hello!</p>") do
       @message.broadcast_prepend
     end
   end
@@ -97,7 +97,7 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasting action now" do
-    assert_broadcast_on @message.to_param, turbo_stream_action_tag("prepend", target: "messages", template: "<p>Hello!</p>") do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: "<p>Hello!</p>") do
       @message.broadcast_action "prepend"
     end
   end

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -21,7 +21,7 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
 
   test "broadcasting remove now with record" do
     assert_broadcast_on "stream", turbo_stream_action_tag("remove", target: "message_1") do
-      Turbo::StreamsChannel.broadcast_remove_to "stream", target: Message.new(record_id: 1, content: "hello!")
+      Turbo::StreamsChannel.broadcast_remove_to "stream", target: Message.new(id: 1, content: "hello!")
     end
   end
 

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -1,12 +1,14 @@
 require "application_system_test_case"
 
 class BroadcastsTest < ApplicationSystemTestCase
+  setup { Message.delete_all }
+
   test "Message broadcasts Turbo Streams" do
     visit messages_path
 
     assert_text "Messages"
-    assert_appends_text "Message 1" do |text|
-      Message.new(record_id: 1, content: text).broadcast_append_to(:messages)
+    assert_broadcasts_text "Message 1" do |text|
+      Message.create(content: text).broadcast_append_to(:messages)
     end
   end
 
@@ -14,14 +16,14 @@ class BroadcastsTest < ApplicationSystemTestCase
     visit users_profiles_path
 
     assert_text "Users::Profiles"
-    assert_appends_text "Profile 1" do |text|
+    assert_broadcasts_text "Profile 1" do |text|
       Users::Profile.new(id: 1, name: text).broadcast_append_to(:users_profiles)
     end
   end
 
   private
 
-    def assert_appends_text(text, &block)
+    def assert_broadcasts_text(text, &block)
       assert_no_text text
       perform_enqueued_jobs { block.call(text) }
       assert_text text


### PR DESCRIPTION
In an effort to reduce the number of flaky tests and the amount of
in-memory state leaking between tests, this commit promotes the test
suite's dummy application's `Message` object to an `ApplicationRecord`
descendant.

Something in the test suite configuration is preventing the database
from being wiped between test runs. This results in state leaking
between tests. As a result, our Continuous Integration tests are flaky.

This commit introduces a short-term remedy by adding a `setup {
Message.delete_all }` block to the `test/system/broadcasts_test.rb`.
This should be unnecessary, but until we determine to root cause, it
helps pass the suite more consistently.
