### PR TITLE
Fix the failing redis installation comment

### DIFF
--- a/lib/install/turbo_needs_redis.rb
+++ b/lib/install/turbo_needs_redis.rb
@@ -7,7 +7,8 @@ if (cable_config_path = Rails.root.join("config/cable.yml")).exist?
   if gemfile_content.match?(pattern)
     uncomment_lines "Gemfile", pattern
   else
-    gem 'redis', '~> 4.0', comment: "Use Redis as Action Cable adapter instead of default Async. The Async adapter\ndoes not support Turbo Stream broadcasting."
+    append_file "Gemfile", "\n# Use Redis as Action Cable adapter instead of default Async. The Async adapter\ndoes not support Turbo Stream broadcasting."
+    gem 'redis', '~> 4.0'
   end
 
   run_bundle


### PR DESCRIPTION
I run the `./bin/rails turbo:install` and it has failed because [redis gem was added with incorrect flag](https://github.com/hotwired/turbo-rails/blob/6c8586ba5e81f9952c4cf74f09c2a1364c3a80f1/lib/install/turbo_needs_redis.rb#L10) so the `Gemfile` couldn't be parsed  anymore. The `:comment` is not a valid option for the `redis` gem.

Moving the comment to the line above as a "regular comment" solved the issue for me.