### PR TITLE
Make it easier to opt out of precompilation

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -20,9 +20,17 @@ module Turbo
       Rails.autoloaders.once.do_not_eager_load(Dir["#{root}/app/channels/turbo/*_channel.rb"]) unless defined?(ActionCable)
     end
 
+    # If you don't want to precompile Turbo's assets (eg. because you're using webpack),
+    # you can do this in an intiailzer:
+    #
+    # config.after_initialize do
+    #   config.assets.precompile -= Turbo::Engine::PRECOMPILE_ASSETS
+    # end
+    PRECOMPILE_ASSETS = %w( turbo.js turbo.min.js )
+
     initializer "turbo.assets" do
       if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += %w( turbo.js turbo.min.js )
+        Rails.application.config.assets.precompile += PRECOMPILE_ASSETS
       end
     end
 


### PR DESCRIPTION
If you don't want to use use the asset pipeline to precompile `turbo.js`, it is not clear how to opt out at the moment. This makes it a bit easier to by introducing a const. I copied the pattern in [sprockets](https://github.com/rails/sprockets-rails/blob/118ce60b1ffeb7a85640661b014cd2ee3c4e3e56/lib/sprockets/railtie.rb#L85.

A reason why you might want this is if you're using webpack to build your JS (but still want the `turbo-rails` gem for the server side helpers it adds).

I think a configuration option for this would be even better, but the gem has no other config so far and I wasn't sure if this was a good enough reason to break that.