### PR TITLE
Disable CSRF when rendering from turbo

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -83,6 +83,6 @@ module Turbo::Streams::Broadcasts
 
   private
     def render_format(format, **rendering)
-      ApplicationController.render(formats: [ format ], **rendering)
+      Turbo::Controller.render(formats: [ format ], **rendering)
     end
 end

--- a/app/controllers/turbo/controller.rb
+++ b/app/controllers/turbo/controller.rb
@@ -1,0 +1,7 @@
+class Turbo::Controller < ApplicationController
+  private
+
+    def protect_against_forgery?
+      false
+    end
+end

--- a/test/dummy/config/initializers/application_controller_renderer.rb
+++ b/test/dummy/config/initializers/application_controller_renderer.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do
-#   ApplicationController.renderer.defaults.merge!(
+#   Turbo::Controller.renderer.defaults.merge!(
 #     http_host: 'example.org',
 #     https: false
 #   )

--- a/test/turbo_test.rb
+++ b/test/turbo_test.rb
@@ -12,7 +12,7 @@ ActionCable.server.config.logger = Logger.new(STDOUT) if ENV["VERBOSE"]
 
 module ActionViewTestCaseExtensions
   def render(*arguments, **options, &block)
-    ApplicationController.renderer.render(*arguments, **options, &block)
+    Turbo::Controller.renderer.render(*arguments, **options, &block)
   end
 end
 


### PR DESCRIPTION
Ref: https://github.com/hotwired/turbo-rails/issues/243

CSRF protection requires access to the user session, but it is only available during a regular request cycle, not when rendering from the background.

I think the solution should be something like that.
