### PR TITLE
Problem: system tests failures

### DIFF
--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -3,8 +3,11 @@ require "application_system_test_case"
 class BroadcastsTest < ApplicationSystemTestCase
   setup { Message.delete_all }
 
+  include ActionCable::TestHelper
+
   test "Message broadcasts Turbo Streams" do
     visit messages_path
+    wait_for_subscriber
 
     assert_text "Messages"
     assert_broadcasts_text "Message 1" do |text|
@@ -14,6 +17,7 @@ class BroadcastsTest < ApplicationSystemTestCase
 
   test "New messages update the message count with html" do
     visit messages_path
+    wait_for_subscriber
 
     assert_text "Messages"
     message = Message.create(content: "A new message")
@@ -25,6 +29,7 @@ class BroadcastsTest < ApplicationSystemTestCase
 
   test "Users::Profile broadcasts Turbo Streams" do
     visit users_profiles_path
+    wait_for_subscriber
 
     assert_text "Users::Profiles"
     assert_broadcasts_text "Profile 1" do |text|
@@ -34,9 +39,26 @@ class BroadcastsTest < ApplicationSystemTestCase
 
   private
 
-    def assert_broadcasts_text(text, wait: 5, &block)
-      assert_no_text text
-      perform_enqueued_jobs { block.call(text) }
-      assert_text text, wait: wait
+  def assert_broadcasts_text(text, wait: 5, &block)
+    assert_no_text text
+    perform_enqueued_jobs { block.call(text) }
+    assert_text text, wait: wait
+  end
+
+  def wait_for_subscriber(timeout: 10)
+    time = Time.now
+    loop do
+      subscriber_map = pubsub_adapter.instance_variable_get(:@subscriber_map)
+      if subscriber_map.is_a?(ActionCable::SubscriptionAdapter::SubscriberMap)
+        subscribers = subscriber_map.instance_variable_get(:@subscribers)
+        sync = subscriber_map.instance_variable_get(:@sync)
+        sync.synchronize do
+          return unless subscribers.empty?
+        end
+      end
+      assert_operator(Time.now - time, :<, timeout, "subscriber waiting timed out")
+      sleep 0.1
     end
+  end
+
 end


### PR DESCRIPTION
Some or all system test fail most of the time.

Solution: ensure there's a subscriber when we broadcast

The original tests waited for the page but didn't ensure whether
the page is subscribed to the channel (which happens asynchronously).

This change makes these tests wait for at least one subscriber to
become available.

It is admittedly a hacky way to wait as it relies on internals of
ActionCable but it does seem to work. Maybe it is a signal that this
type of helper should become a part of ActionCable's own set of test
helpers?