### PR TITLE
fix a little typo for wrong constant name

### DIFF
--- a/app/channels/turbo/streams_channel.rb
+++ b/app/channels/turbo/streams_channel.rb
@@ -9,7 +9,7 @@
 # helper modules like <tt>Turbo::Streams::StreamName</tt>:
 #
 #   class CustomChannel < ActionCable::Channel::Base
-#      extend Turbo::Stream::Broadcasts, Turbo::Streams::StreamName
+#      extend Turbo::Streams::Broadcasts, Turbo::Streams::StreamName
 #      include Turbo::Streams::StreamName::ClassMethods
 #
 #      def subscribed


### PR DESCRIPTION
https://rubydoc.info/gems/turbo-rails/0.9.0/Turbo/StreamsChannel

When copied from documentation and compared to whats in source code https://github.com/hotwired/turbo-rails/blob/e9b5f68ff81184e2641c6faaedf13e9beedc71ff/app/channels/turbo/streams_channel.rb you can see the typo