### PR TITLE
Turbo::Broadcastable#broadcasts broadcasts creates to model_name.plural stream

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -71,9 +71,10 @@ module Turbo::Broadcastable
       after_destroy_commit -> { broadcast_remove_to stream.try(:call, self) || send(stream) }
     end
 
-    # Same as <tt>#broadcasts_to</tt>, but the designated stream is automatically set to the current model.
-    def broadcasts(inserts_by: :append, target: broadcast_target_default)
-      after_create_commit  -> { broadcast_action_later action: inserts_by, target: target.try(:call, self) || target }
+    # Same as <tt>#broadcasts_to</tt>, but the designated stream for updates and destroys is automatically set to
+    # the current model, for creates - to the model plural name, which can be overriden by passing <tt>stream</tt>.
+    def broadcasts(stream = model_name.plural, inserts_by: :append, target: broadcast_target_default)
+      after_create_commit  -> { broadcast_action_later_to stream, action: inserts_by, target: target.try(:call, self) || target }
       after_update_commit  -> { broadcast_replace_later }
       after_destroy_commit -> { broadcast_remove }
     end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -3,7 +3,7 @@ class Article < ApplicationRecord
 
   validates :body, presence: true
 
-  broadcasts target: "overriden-target"
+  broadcasts "overriden-stream", target: "overriden-target"
 
   def to_gid_param
     to_param

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -121,7 +121,7 @@ class Turbo::BroadcastableArticleTest < ActionCable::Channel::TestCase
   include ActiveJob::TestHelper, Turbo::Streams::ActionHelper
 
   test "creating an article broadcasts to the overriden target with a string" do
-    assert_broadcast_on "body", turbo_stream_action_tag("append", target: "overriden-target", template: "<p>Body</p>\n") do
+    assert_broadcast_on "overriden-stream", turbo_stream_action_tag("append", target: "overriden-target", template: "<p>Body</p>\n") do
       perform_enqueued_jobs do
         Article.create!(body: "Body")
       end


### PR DESCRIPTION
As mentioned in https://github.com/hotwired/turbo-rails/issues/171, `Turbo::Broadcastable#broadcasts` provides the stream for broadcasting creates that can't be on the page until the model instance is created.
The issue was closed without any conversation and I didn't find any topics at Hotwire forum about this problem.
My solution is to broadcast instance creation to stream with model plural name, which looks quite intuitive for me.

My apologies if i missed something.