### PR TITLE
Add possibility to nest turbo frames

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -23,8 +23,8 @@ module Turbo::FramesHelper
   #     <div>My tray frame!</div>
   #   <% end %>
   #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
-  def turbo_frame_tag(id, src: nil, target: nil, **attributes, &block)
-    id = id.respond_to?(:to_key) ? dom_id(id) : id
+  def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
+    id = ids.map { |id| id.respond_to?(:to_key) ? dom_id(id) : id }.join("_")
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -23,6 +23,19 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
   end
 
+  test "string frame nested withing a model frame" do
+    record = Article.new(id: 1)
+
+    assert_dom_equal %(<turbo-frame id="article_1_comments"></turbo-frame>), turbo_frame_tag(record, "comments")
+  end
+
+  test "model frame nested withing another model frame" do
+    record = Article.new(id: 1)
+    nested_record = Comment.new
+
+    assert_dom_equal %(<turbo-frame id="article_1_new_comment"></turbo-frame>), turbo_frame_tag(record, nested_record)
+  end
+
   test "block style" do
     assert_dom_equal(%(<turbo-frame id="tray"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
   end


### PR DESCRIPTION
I often get the case where I would like to nest turbo frames.

Let's take the example of the `Article` and the `Comment` models of the dummy app. Let's imagine that on the `Articles#index` page, we display multiple articles and we want to be able to add comments to them directly from this page.

![articles-comments](https://user-images.githubusercontent.com/33979976/148256910-1e64c4e8-3389-4dbf-8b85-8ed4acad2a90.png)

When clicking on the "Add comment" button of the article with id 1, I need to append the new comment form on the right article, so I need a `<turbo-frame id="article_1_new_comment">`. I would like to be able to write it like this `turbo_frame_tag(@article, Comment.new)`.

When submitting the form, I need to add the created comment at the right position so again, I need the nesting `<turbo-frame id="article_1_comments">` to be able to append the comment in the comments list of the article with id 1. I would like to be able to write it like this `turbo_frame_tag(@article, "comments")`.

What do you think? It would be nice to have a convention to prevent each developer team from writing its own `nested_dom_id` helper.