### PR TITLE
Add Turbo::Broadcastable support for #broadcast_render and #broadcast_render_to

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -45,8 +45,9 @@
 # within a real-time path, like a controller or model, since all those updates require a rendering step, which can slow down
 # execution. You don't need to do this for remove, since only the dom id for the model is used.
 #
-# In addition to the four basic actions, you can also use <tt>broadcast_render_later</tt> or
-# <tt>broadcast_render_later_to</tt> to render a turbo stream template with multiple actions.
+# In addition to the four basic actions, you can also use <tt>broadcast_render</tt>,
+# <tt>broadcast_render_to</tt> <tt>broadcast_render_later</tt>, and <tt>broadcast_render_later_to</tt>
+# to render a turbo stream template with multiple actions.
 module Turbo::Broadcastable
   extend ActiveSupport::Concern
 
@@ -275,9 +276,7 @@ module Turbo::Broadcastable
     broadcast_action_later_to self, action: action, target: target, **rendering
   end
 
-
-  # Render a turbo stream template asynchronously with this broadcastable model passed as the local variable using a
-  # <tt>Turbo::Streams::BroadcastJob</tt>. Example:
+  # Render a turbo stream template with this broadcastable model passed as the local variable. Example:
   #
   #   # Template: entries/_entry.turbo_stream.erb
   #   <%= turbo_stream.remove entry %>
@@ -290,6 +289,17 @@ module Turbo::Broadcastable
   #   <turbo-stream action="append" target="entries"><template><div id="entry_5">My Entry</div></template></turbo-stream>
   #
   # ...to the stream named "entry:5"
+  def broadcast_render(**rendering)
+    broadcast_render_to self, **rendering
+  end
+
+  # Same as <tt>broadcast_render</tt> but run with the added option of naming the stream using the passed
+  # <tt>streamables</tt>.
+  def broadcast_render_to(*streamables, **rendering)
+    Turbo::StreamsChannel.broadcast_render_to(*streamables, **broadcast_rendering_with_defaults(rendering))
+  end
+
+  # Same as <tt>broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_render_later(**rendering)
     broadcast_render_later_to self, **rendering
   end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -288,13 +288,21 @@ module Turbo::Broadcastable
   #   <turbo-stream action="remove" target="entry_5"></turbo-stream>
   #   <turbo-stream action="append" target="entries"><template><div id="entry_5">My Entry</div></template></turbo-stream>
   #
-  # ...to the stream named "entry:5"
+  # ...to the stream named "entry:5".
+  #
+  # Note that rendering inline via this method will cause template rendering to happen synchronously. That is usually not
+  # desireable for model callbacks, certainly not if those callbacks are inside of a transaction. Most of the time you should
+  # be using `broadcast_render_later`, unless you specifically know why synchronous rendering is needed.
   def broadcast_render(**rendering)
     broadcast_render_to self, **rendering
   end
 
   # Same as <tt>broadcast_render</tt> but run with the added option of naming the stream using the passed
   # <tt>streamables</tt>.
+  #
+  # Note that rendering inline via this method will cause template rendering to happen synchronously. That is usually not
+  # desireable for model callbacks, certainly not if those callbacks are inside of a transaction. Most of the time you should
+  # be using `broadcast_render_later_to`, unless you specifically know why synchronous rendering is needed.
   def broadcast_render_to(*streamables, **rendering)
     Turbo::StreamsChannel.broadcast_render_to(*streamables, **broadcast_rendering_with_defaults(rendering))
   end

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -115,6 +115,19 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
       @profile.broadcast_replace partial: 'messages/message', locals: { message: @message }
     end
   end
+
+  test "broadcast render now" do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("replace", target: "message_1", template: "Goodbye!") do
+      @message.broadcast_render
+    end
+  end
+
+  test "broadcast render to stream now" do
+    @profile = Users::Profile.new(id: 1, name: "Ryan")
+    assert_broadcast_on @profile.to_param, turbo_stream_action_tag("replace", target: "message_1", template: "Goodbye!") do
+      @message.broadcast_render_to @profile
+    end
+  end
 end
 
 class Turbo::BroadcastableArticleTest < ActionCable::Channel::TestCase


### PR DESCRIPTION
This is very useful for when a destroy action contains a lot of functionality.

`app/views/messages/_destroy.turbo_stream.erb`
```erb
<%= turbo_stream.replace(dom_id(message, :modal_body)) do %>
  <%= render "messages/body", message: message %>
<% end %>

<%= turbo_stream.remove(dom_id(message, :outer)) %>

<% if message.item.messages.none? %>
  <%= turbo_stream.remove(dom_id(message.item, :messages)) %>
<% end %>
```

`app/models/message.rb`
```ruby
class Message < ApplicationRecord
  after_destroy_commit {
    broadcast_render partial: "messages/destroy"
  }
end
```

Right now it's possible but I have to call `Turbo::StreamsChannel` directly:
```ruby
class Message < ApplicationRecord
  after_destroy_commit {
    Turbo::StreamsChannel.broadcast_render **broadcast_rendering_with_defaults(partial: "messages/destroy")
  }
end
```