### PR TITLE
Use where on Windows instead of which (#299)

### DIFF
--- a/lib/tasks/turbo_tasks.rake
+++ b/lib/tasks/turbo_tasks.rake
@@ -3,7 +3,9 @@ def run_turbo_install_template(path)
 end
 
 def redis_installed?
-  system('which redis-server > /dev/null')
+  Gem.win_platform? ?
+    system('where redis-server > NUL 2>&1') : 
+    system('which redis-server > /dev/null')
 end
 
 def switch_on_redis_if_available


### PR DESCRIPTION
If the call is on Windows, it uses `where` instead of `which` and correctly sends the output to NUL so that it does not show unnecessary message on the installer's output. This fixes the incorrect/ misleading message shown on Windows currently.