### PR TITLE
Fix breaking in non-Zeitwerk environment

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -16,8 +16,8 @@ module Turbo
       #{root}/app/jobs
     )
 
-    initializer "turbo.no_action_cable" do
-      Rails.autoloaders.once.do_not_eager_load(Dir["#{root}/app/channels/turbo/*_channel.rb"]) unless defined?(ActionCable)
+    initializer "turbo.no_action_cable", before: :set_eager_load_paths do
+      config.eager_load_paths.delete("#{root}/app/channels") unless defined?(ActionCable)
     end
 
     # If you don't want to precompile Turbo's assets (eg. because you're using webpack),


### PR DESCRIPTION
I'm trying to use turbo-rails in our project, but with JRuby and Rails 6.1 the Rails app fails to start with emitting the following error:

```
rake aborted!
NoMethodError: undefined method `do_not_eager_load' for nil:NilClass
/home/runner/work/rails_admin/rails_admin/vendor/bundle/jruby/2.6.0/gems/turbo-rails-1.0.1/lib/turbo/engine.rb:20:in `block in Engine'
/home/runner/work/rails_admin/rails_admin/vendor/bundle/jruby/2.6.0/gems/railties-6.1.4.4/lib/rails/initializable.rb:32:in `run'
/home/runner/work/rails_admin/rails_admin/vendor/bundle/jruby/2.6.0/gems/railties-6.1.4.4/lib/rails/initializable.rb:61:in `block in run_initializers'
/home/runner/work/rails_admin/rails_admin/vendor/bundle/jruby/2.6.0/gems/railties-6.1.4.4/lib/rails/initializable.rb:50:in `tsort_each_child'
...
```
https://github.com/railsadminteam/rails_admin/runs/4995149973?check_suite_focus=true

What I found was that Rails 6.1 with JRuby doesn't enable the Zeitwerk by default, which results in the value of `Rails.autoloaders.once` to be nil.
https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/autoloaders.rb#L19-L26

So my fix here is to call `do_not_eager_load` only if Zeitwerk is enabled. This will prevent stopping eager-load of files under `app/channels/turbo/` in non-Zeitwerk environment, but for most of users it won't be a problem because they should have ActionCable loaded in a normal Rails setup. Or if there's a better implementation I'd be glad to adopt it.

Thanks in advance!