### PR TITLE
Fix CI with Rails main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Run tests
         run: |
-          bin/rails db:test:prepare
           bin/test test/**/*_test.rb
       - name: Fail when generated changes are not checked-in
         run: |

--- a/bin/test
+++ b/bin/test
@@ -10,8 +10,8 @@ puts "Installing JavaScript dependencies"
 puts "Building JavaScript"
 `yarn build`
 
-puts "Migrating test database"
-`cd test/dummy; RAILS_ENV=test ./bin/rails db:migrate db:test:prepare`
+puts "Preparing test database"
+`cd test/dummy; ./bin/rails db:test:prepare`
 
 require "bundler/setup"
 require "rails/plugin/test"


### PR DESCRIPTION
Migrating the test dummy app database while testing against Rails main rewrites `db/schema.rb` in the new format, [causing CI to fail](https://github.com/hotwired/turbo-rails/runs/5213359938?check_suite_focus=true) as @yrashk noticed in #308:

![test/dummy/db/schema.rb: needs update](https://user-images.githubusercontent.com/15299/158040936-099f42ef-8a18-47c6-bfda-003ede5a432e.png)

Removing the `db:migrate` task from the test script and using only `db:test:prepare` will avoid rewriting the schema file in CI.