### PR TITLE
Add :targets to assert_turbo_stream

### DIFF
--- a/lib/turbo/test_assertions.rb
+++ b/lib/turbo/test_assertions.rb
@@ -7,15 +7,21 @@ module Turbo
       delegate :dom_id, :dom_class, to: ActionView::RecordIdentifier
     end
 
-    def assert_turbo_stream(action:, target: nil, status: :ok, &block)
+    def assert_turbo_stream(action:, target: nil, targets: nil, status: :ok, &block)
       assert_response status
       assert_equal Mime[:turbo_stream], response.media_type
-      assert_select %(turbo-stream[action="#{action}"][target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]), count: 1, &block
+      selector =  %(turbo-stream[action="#{action}"])
+      selector << %([target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]) if target
+      selector << %([targets="#{targets}"]) if targets
+      assert_select selector, count: 1, &block
     end
 
-    def assert_no_turbo_stream(action:, target: nil)
+    def assert_no_turbo_stream(action:, target: nil, targets: nil)
       assert_equal Mime[:turbo_stream], response.media_type
-      assert_select %(turbo-stream[action="#{action}"][target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]), count: 0
+      selector =  %(turbo-stream[action="#{action}"])
+      selector << %([target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]) if target
+      selector << %([targets="#{targets}"]) if targets
+      assert_select selector, count: 0
     end
   end
 end

--- a/test/dummy/app/views/messages/update.turbo_stream.erb
+++ b/test/dummy/app/views/messages/update.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.remove_all @message %>
 <%= turbo_stream.replace_all @message %>
 <%= turbo_stream.replace_all @message, "Something else" %>
-<%= turbo_stream.replace_all "#message_5", "Something fifth" %>
+<%= turbo_stream.replace_all "#message_4", "Something fourth" %>
 <%= turbo_stream.replace_all "#message_5", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
 <%= turbo_stream.append_all "#messages", @message %>
 <%= turbo_stream.append_all "#messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -37,11 +37,14 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
 
     patch message_path(id: 1), as: :turbo_stream
 
+    assert_turbo_stream action: :replace, targets: "#message_4" do
+      assert_select 'template', 'Something fourth'
+    end
     assert_dom_equal <<~HTML, @response.body
       <turbo-stream action="remove" targets="#message_1"></turbo-stream>
       <turbo-stream action="replace" targets="#message_1"><template>#{render(message_1)}</template></turbo-stream>
       <turbo-stream action="replace" targets="#message_1"><template>Something else</template></turbo-stream>
-      <turbo-stream action="replace" targets="#message_5"><template>Something fifth</template></turbo-stream>
+      <turbo-stream action="replace" targets="#message_4"><template>Something fourth</template></turbo-stream>
       <turbo-stream action="replace" targets="#message_5"><template>#{render(message_5)}</template></turbo-stream>
       <turbo-stream action="append" targets="#messages"><template>#{render(message_1)}</template></turbo-stream>
       <turbo-stream action="append" targets="#messages"><template>#{render(message_5)}</template></turbo-stream>


### PR DESCRIPTION
This PR adds a `:targets` argument to `assert_turbo_stream` and `assert_no_turbo_stream` which parallels the dual `:target` vs `:targets` syntax elsewhere.
