### PR TITLE
Add `append_body` and `prepend_body` methods to TagBuilder

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -224,7 +224,7 @@ class Turbo::Streams::TagBuilder
     action_all :prepend, targets, content, **rendering, &block
   end
 
-  # Preped to the <body> tag of the document either the <tt>content</tt> passed in or a
+  # Prepend to the <body> tag of the document either the <tt>content</tt> passed in or a
   # rendering result determined by the <tt>rendering</tt> keyword arguments, the content in the block,
   # or the rendering of the content as a record. Examples:
   #


### PR DESCRIPTION
Sometimes you just want to add content "anywhere" on the page:
- Common for adding modals/tooltips with absolute/fixed position
- Stimulus controllers that run one-off functions (e.g. [callout_controller](https://github.com/hotwired/stimulus-site/blob/35a4d71754278ae5ecdfc51fedd06b87a28b285b/_source/reference/lifecycle_callbacks.md?plain=1#L10) from Stimulus website, [Beacons](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API), etc)
- Adding extra `<script>` tags for 3rd party tools

The Rails helpers supports this, but you would need to use `prepend_all` so you could pass in "body" as the query selector (`prepend "body"` would try to look for an element with `id=body`). This doesn't read well since you won't have multiple `<body>` tags.

This PR adds helpers (`append_body` and `prepend_body`) for appending or prepending content to the `<body>` tag of the document directly.

![image](https://user-images.githubusercontent.com/56947/162452329-210a7690-db78-4a37-b62d-f3dfc000c268.png)
