### PR TITLE
Offer a flag to opt-out of native routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
-# FIXME: Offer flag to opt out of these native routes
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   get "recede_historical_location"  => "turbo/native/navigation#recede",  as: :turbo_recede_historical_location
   get "resume_historical_location"  => "turbo/native/navigation#resume",  as: :turbo_resume_historical_location
   get "refresh_historical_location" => "turbo/native/navigation#refresh", as: :turbo_refresh_historical_location
-end
+end if Turbo.draw_routes

--- a/lib/turbo-rails.rb
+++ b/lib/turbo-rails.rb
@@ -3,6 +3,8 @@ require "turbo/engine"
 module Turbo
   extend ActiveSupport::Autoload
 
+  mattr_accessor :draw_routes, default: true
+
   class << self
     attr_writer :signed_stream_verifier_key
 

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -28,6 +28,12 @@ module Turbo
     # end
     PRECOMPILE_ASSETS = %w( turbo.js turbo.min.js turbo.min.js.map )
 
+    initializer "turbo.configs" do
+      config.after_initialize do |app|
+        Turbo.draw_routes = app.config.turbo.draw_routes != false
+      end
+    end
+
     initializer "turbo.assets" do
       if Rails.application.config.respond_to?(:assets)
         Rails.application.config.assets.precompile += PRECOMPILE_ASSETS


### PR DESCRIPTION
In this PR, we add the `config.turbo.draw_routes` configuration option to opt-out of
native routes.