### PR TITLE
Make `turbo_test.rb` consistent with Rails' generated `test_helper.rb`

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]

--- a/test/drive/drive_helper_test.rb
+++ b/test/drive/drive_helper_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class Turbo::DriveHelperTest < ActionDispatch::IntegrationTest
   test "opting out of the default cache" do

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
   test "frame requests are rendered without a layout" do

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -1,8 +1,6 @@
-require "turbo_test"
+require "test_helper"
 
 class Turbo::FramesHelperTest < ActionView::TestCase
-  setup { Message.delete_all }
-
   test "frame with src" do
     assert_dom_equal %(<turbo-frame src="/trays/1" id="tray"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1")
   end

--- a/test/initializers/helpers_test.rb
+++ b/test/initializers/helpers_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class Turbo::HelpersInInitializersTest < ActionDispatch::IntegrationTest
   test "AC::Base has the helpers in place when initializers run" do

--- a/test/native/navigation_controller_test.rb
+++ b/test/native/navigation_controller_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class Turbo::Native::NavigationControllerTest < ActionDispatch::IntegrationTest
   test "recede, resume, or refresh when native or redirect when not" do

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 require "action_cable"
 
 class Turbo::BroadcastableTest < ActionCable::Channel::TestCase

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 require "action_cable"
 
 class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
   test "create with respond to" do

--- a/test/streams/streams_helper_test.rb
+++ b/test/streams/streams_helper_test.rb
@@ -1,4 +1,4 @@
-require "turbo_test"
+require "test_helper"
 
 class TestChannel < ApplicationCable::Channel; end
 

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -1,8 +1,6 @@
 require "application_system_test_case"
 
 class BroadcastsTest < ApplicationSystemTestCase
-  setup { Message.delete_all }
-
   include ActionCable::TestHelper
 
   test "Message broadcasts Turbo Streams" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,10 @@
+# Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require "minitest/autorun"
-require "rails"
-require "rails/test_help"
-require "byebug"
-
-require_relative "dummy/config/environment"
-
+require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
+require "rails/test_help"
+
 ActionCable.server.config.logger = Logger.new(STDOUT) if ENV["VERBOSE"]
 
 module ActionViewTestCaseExtensions


### PR DESCRIPTION
I've opened this as a draft PR, since I'm unsure about the root-cause of database records leaking across test runs
---

> Something in the test suite configuration is preventing the database
> from being wiped between test runs. This results in state leaking
> between tests. As a result, our Continuous Integration tests are flaky.
>
> -- [hotwired/turbo-rails#248][]

As a follow-up to the [short-term solution][] shipped in
[hotwired/turbo-rails#248][], this commit attempts to make the
`test/turbo_test.rb` file's setup consistent with the test harness setup
generated by Rails' [engine generator][] code.

To that end, this commit:

* renames the `test/turbo_test.rb` file to `test/test_helper.rb`
* omits one-off `require` calls for particular dependencies
* re-orders the require calls so that the
  `../test/dummy/config/environment` file is required ahead of the
  `rails/test_help` file

[engine generator]: https://github.com/rails/rails/blob/3c48b4030adbded21bebaa0d78254216cca48a6e/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
[hotwired/turbo-rails#248]: https://github.com/hotwired/turbo-rails/pull/248
[short-term solution]: https://github.com/hotwired/turbo-rails/commit/c2dc5b15acaf3cb0aebb581b7dfa0b792ec50bc1