### PR TITLE
Document the turbo_frame_tag helper with multiple arguments

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -23,6 +23,18 @@ module Turbo::FramesHelper
   #     <div>My tray frame!</div>
   #   <% end %>
   #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
+  #
+  # The `turbo_frame_tag` helper will convert the arguments it receives to their
+  # `dom_id` if applicable to easily generate unique ids for Turbo Frames:
+  #
+  #   <%= turbo_frame_tag(Article.find(1)) %>
+  #   # => <turbo-frame id="article_1"></turbo-frame>
+  #
+  #   <%= turbo_frame_tag(Article.find(1), "comments") %>
+  #   # => <turbo-frame id="article_1_comments"></turbo-frame>
+  #
+  #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
+  #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
     id = ids.map { |id| id.respond_to?(:to_key) ? dom_id(id) : id }.join("_")
     src = url_for(src) if src.present?


### PR DESCRIPTION
Following #296, this PR adds documentation for the `turbo_frame_tag` helper when it receives multiple arguments.