### PR TITLE
Fix missing `activejob` dependency

### DIFF
--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.6.0"
 
+  s.add_dependency "activejob", ">= 6.0.0"
   s.add_dependency "actionpack", ">= 6.0.0"
   s.add_dependency "railties", ">= 6.0.0"
 


### PR DESCRIPTION
closes https://github.com/hotwired/turbo-rails/issues/330

Removed in https://github.com/hotwired/turbo-rails/pull/283/commits/aea2fecafdb304c2c55820bae456afdf729f75d3 (which this effectively reverts, that change was a part of https://github.com/hotwired/turbo-rails/pull/283), `ActiveJob` is used in a couple areas https://github.com/hotwired/turbo-rails/blob/b9b87fc627d9148899970deea01069875f15db3f/app/jobs/turbo/streams/broadcast_job.rb#L3 and https://github.com/hotwired/turbo-rails/blob/b9b87fc627d9148899970deea01069875f15db3f/app/jobs/turbo/streams/action_broadcast_job.rb#L2