### PR TITLE
call dom_id explicitly in turbo_frame_tag

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -36,7 +36,7 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
   #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
-    id = ids.map { |id| id.respond_to?(:to_key) ? dom_id(id) : id }.join("_")
+    id = ids.map { |id| id.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(id) : id }.join("_")
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)


### PR DESCRIPTION
Before the Turbo era, `dom_id` was a view helper. Many developers and libraries such as [CableReady](https://cableready.stimulusreflex.com) introduced a server-side `dom_id` method, which prepends a `#` to the returned string.

We want CableReady and Turbo Streams to be able to peacefully coexist. This modification to the `turbo_frame_tag` helper would prevent unexpected behaviour where a Stream context would pick up the wrong `dom_id` method.

A slightly more explicit call, which is entirely transparent to the developer, would ease many headaches.