### PR TITLE
Rails default key generator hash digest class is respected

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -61,8 +61,10 @@ module Turbo
     end
 
     initializer "turbo.signed_stream_verifier_key" do
-      Turbo.signed_stream_verifier_key = config.turbo.signed_stream_verifier_key ||
-        Rails.application.key_generator.generate_key("turbo/signed_stream_verifier_key")
+      config.after_initialize do
+        Turbo.signed_stream_verifier_key = config.turbo.signed_stream_verifier_key ||
+          Rails.application.key_generator.generate_key("turbo/signed_stream_verifier_key")
+      end
     end
 
     initializer "turbo.test_assertions" do


### PR DESCRIPTION
Without this, turbo-rails inadvertently forces Rails.application.key_generator
to use SHA1, rather than the Rails 7 default.

Fixes #325