### PR TITLE
Broadcastable defaults, Conditionally Append `self`

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -325,7 +325,7 @@ module Turbo::Broadcastable
   end
 
 
-  private
+  private do
     def broadcast_target_default
       self.class.broadcast_target_default
     end
@@ -334,11 +334,14 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
+        o[:locals] = (o[:locals] || {})
+        # Conditionally so background rendering can be used for destroyed records.
+        o[:locals].reverse_merge!(model_name.element.to_sym => self) if self.persisted?
         # if the html option is passed in it will skip setting a partial from #to_partial_path
         unless o.include?(:html)
           o[:partial] ||= to_partial_path
         end
       end
     end
+  end
 end

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -145,9 +145,11 @@ class Turbo::BroadcastableArticleTest < ActionCable::Channel::TestCase
     article = Article.create!(body: "Hey")
 
     assert_broadcast_on "ho", turbo_stream_action_tag("replace", target: "article_#{article.id}", template: "<p>Ho</p>\n") do
-      perform_enqueued_jobs do
-        article.update!(body: "Ho")
-      end
+      article.update!(body: "Ho")
+
+      expect(Turbo::Streams::ActionBroadcastJob).to(
+        have_been_enqueued.with(article: article, action: "replace", target: "article_#{article.id}", template: "<p>Ho</p>\n")
+      )
     end
   end
 
@@ -156,6 +158,10 @@ class Turbo::BroadcastableArticleTest < ActionCable::Channel::TestCase
 
     assert_broadcast_on "hey", turbo_stream_action_tag("remove", target: "article_#{article.id}") do
       article.destroy!
+
+      expect(Turbo::Streams::ActionBroadcastJob).to(
+        have_been_enqueued.with(action: "remove", target: "article_#{article.id}")
+      )
     end
   end
 end


### PR DESCRIPTION
# Outline

When using `broadcast_update_to` the content is streamed as expected on create and destroy. However, when using `broadcast_update_later_to`, the destroy stream is not getting streamed because of the current record being passed as a local by `Turbo::Broadcastable#broadcast_rendering_with_defaults`. This creates the following error:
- "ERROR: Discarded Turbo::Streams::ActionBroadcastJob due to a ActiveJob::DeserializationError". The actual message from `ActiveJob::DeserializationError` reads "Couldn't find Like with 'id'=282"

So this got me wondering whether I'm approaching a certain feature inappropriately or not. I think my approach is okay since I'm working with a `counter_cache`. I cannot stream the counter cache change from within the parent model unless I make the counter cache custom so record callbacks get triggered. I do not want to do this as I believe sticking to Rails defaults is the way.

The error presents itself because `ActiveJob` is smart and only passes the record id to the job to avoid useless memory allocation. I understand the benefit of passing the record as a local but, depending on the requirements, it creates this unexpected behaviour.

My question is, should we be merging the record to `locals` at all? 🤔 I do like it being merged however I don't think this edge case was anticipated? Not really sure whether we want to do anything about this?