### PR TITLE
Change redirect status code for native navigation to 303

### DIFF
--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -34,7 +34,9 @@ module Turbo::Native::Navigation
   # :nodoc:
   def turbo_native_action_or_redirect(url, action, redirect_type, options = {})
     if turbo_native_app?
-      redirect_to send("turbo_#{action}_historical_location_url", notice: options[:notice] || options.delete(:native_notice))
+      redirect_to send("turbo_#{action}_historical_location_url",
+        notice: options[:notice] || options.delete(:native_notice)),
+        status: :see_other
     elsif redirect_type == :back
       redirect_back fallback_location: url, **options
     else


### PR DESCRIPTION
The `303 See Other` code ensures the next request will be a `GET`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303.

It's also the code recommended (required?) by Turbo after a form submission (https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission) so I reckon `303` is the idiomatically correct redirect code to use here.