### PR TITLE
Document how to add a layout for turbo frame requests

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -9,6 +9,20 @@
 # Turbo Frames knows how to fish out the relevant frame regardless.
 #
 # This module is automatically included in <tt>ActionController::Base</tt>.
+#
+# You can override this behavior in <tt>ApplicationController</tt> if you want to have a layout for turbo frame requests:
+#
+#   # app/controllers/articles_controller.rb
+#   class ApplicationController < ActionController::Base
+#     layout -> { "application" if turbo_frame_request? }
+#   end
+#
+# Then, you have to create a layout with the corresponding name. It can be handy for flash messages, for example:
+#
+#   # app/views/layouts/application.turbo_stream.erb
+#   <%= turbo_stream.update('flash', partial: 'layouts/flash') %>
+#
+#   <%= yield %>
 module Turbo::Frames::FrameRequest
   extend ActiveSupport::Concern
 

--- a/app/controllers/turbo/requests.rb
+++ b/app/controllers/turbo/requests.rb
@@ -10,11 +10,11 @@
 #
 # This module is automatically included in <tt>ActionController::Base</tt>.
 #
-# You can override this behavior in <tt>ApplicationController</tt> if you want to have a layout for turbo frame requests:
+# You can override this behavior in <tt>ApplicationController</tt> if you want to have a layout for turbo stream requests:
 #
 #   # app/controllers/articles_controller.rb
 #   class ApplicationController < ActionController::Base
-#     layout -> { "application" if turbo_frame_request? }
+#     layout -> { (turbo_frame_request? && !turbo_stream_request?) ? false : "application" }
 #   end
 #
 # Then, you have to create a layout with the corresponding name. It can be handy for flash messages, for example:
@@ -23,7 +23,7 @@
 #   <%= turbo_stream.update('flash', partial: 'layouts/flash') %>
 #
 #   <%= yield %>
-module Turbo::Frames::FrameRequest
+module Turbo::Requests
   extend ActiveSupport::Concern
 
   included do
@@ -34,6 +34,10 @@ module Turbo::Frames::FrameRequest
   private
     def turbo_frame_request?
       turbo_frame_request_id.present?
+    end
+
+    def turbo_stream_request?
+      request.accept.starts_with?(Mime[:turbo_stream])
     end
 
     def turbo_frame_request_id

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -36,7 +36,7 @@ module Turbo
 
     initializer "turbo.helpers", before: :load_config_initializers do
       ActiveSupport.on_load(:action_controller_base) do
-        include Turbo::Streams::TurboStreamsTagBuilder, Turbo::Frames::FrameRequest, Turbo::Native::Navigation
+        include Turbo::Requests, Turbo::Streams::TurboStreamsTagBuilder, Turbo::Native::Navigation
         helper Turbo::Engine.helpers
       end
     end


### PR DESCRIPTION
References [#178](https://github.com/hotwired/turbo-rails/issues/178#issuecomment-1159654741)

Adding a layout for `turbo frame` requests is a very common feature that is currently not documented. This PR documents how to add a layout for `turbo frame` requests with the common example of flash messages.