### PR TITLE
Add aria-live to assist screen readers for turbo frame

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -5,40 +5,45 @@ module Turbo::FramesHelper
   # === Examples
   #
   #   <%= turbo_frame_tag "tray", src: tray_path(tray) %>
-  #   # => <turbo-frame id="tray" src="http://example.com/trays/1"></turbo-frame>
+  #   # => <turbo-frame id="tray" src="http://example.com/trays/1" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag tray, src: tray_path(tray) %>
-  #   # => <turbo-frame id="tray_1" src="http://example.com/trays/1"></turbo-frame>
+  #   # => <turbo-frame id="tray_1" src="http://example.com/trays/1" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag "tray", src: tray_path(tray), target: "_top" %>
-  #   # => <turbo-frame id="tray" target="_top" src="http://example.com/trays/1"></turbo-frame>
+  #   # => <turbo-frame id="tray" target="_top" src="http://example.com/trays/1" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag "tray", target: "other_tray" %>
-  #   # => <turbo-frame id="tray" target="other_tray"></turbo-frame>
+  #   # => <turbo-frame id="tray" target="other_tray" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag "tray", src: tray_path(tray), loading: "lazy" %>
-  #   # => <turbo-frame id="tray" src="http://example.com/trays/1" loading="lazy"></turbo-frame>
+  #   # => <turbo-frame id="tray" src="http://example.com/trays/1" loading="lazy" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag "tray" do %>
   #     <div>My tray frame!</div>
   #   <% end %>
-  #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
+  #   # => <turbo-frame id="tray" aria-live="polite"><div>My tray frame!</div></turbo-frame>
   #
   # The `turbo_frame_tag` helper will convert the arguments it receives to their
   # `dom_id` if applicable to easily generate unique ids for Turbo Frames:
   #
   #   <%= turbo_frame_tag(Article.find(1)) %>
-  #   # => <turbo-frame id="article_1"></turbo-frame>
+  #   # => <turbo-frame id="article_1" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag(Article.find(1), "comments") %>
-  #   # => <turbo-frame id="article_1_comments"></turbo-frame>
+  #   # => <turbo-frame id="article_1_comments" aria-live="polite"></turbo-frame>
   #
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
-  #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
+  #   # => <turbo-frame id="article_1_new_comment" aria-live="polite"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
     id = ids.map { |id| id.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(id) : id }.join("_")
     src = url_for(src) if src.present?
 
-    tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)
+    attrs = attributes.merge(id: id, src: src, target: target)
+    unless attrs[:"aria-live"].present? || attrs.dig(:"aria", :"live").present?
+      attrs.merge!({"aria-live": "polite"})
+    end
+
+    tag.turbo_frame(**attrs.compact, &block)
   end
 end

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -4,39 +4,45 @@ class Turbo::FramesHelperTest < ActionView::TestCase
   setup { Message.delete_all }
 
   test "frame with src" do
-    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1")
+    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" aria-live="polite"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1")
+  end
+
+  test "frame with aria-live override" do
+    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" aria-live="off"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", aria: { live: "off" })
+    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" aria-live="off"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", "aria-live": "off")
+    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" aria-live="off"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", "aria": { "live": "off" })
   end
 
   test "frame with model src" do
     record = Message.create(id: "1", content: "ignored")
 
-    assert_dom_equal %(<turbo-frame src="/messages/1" id="message"></turbo-frame>), turbo_frame_tag("message", src: record)
+    assert_dom_equal %(<turbo-frame src="/messages/1" id="message" aria-live="polite"></turbo-frame>), turbo_frame_tag("message", src: record)
   end
 
   test "frame with src and target" do
-    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" target="_top"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", target: "_top")
+    assert_dom_equal %(<turbo-frame src="/trays/1" id="tray" target="_top" aria-live="polite"></turbo-frame>), turbo_frame_tag("tray", src: "/trays/1", target: "_top")
   end
 
   test "frame with model argument" do
     record = Message.new(id: "1", content: "ignored")
 
-    assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
+    assert_dom_equal %(<turbo-frame id="message_1" aria-live="polite"></turbo-frame>), turbo_frame_tag(record)
   end
 
   test "string frame nested withing a model frame" do
     record = Article.new(id: 1)
 
-    assert_dom_equal %(<turbo-frame id="article_1_comments"></turbo-frame>), turbo_frame_tag(record, "comments")
+    assert_dom_equal %(<turbo-frame id="article_1_comments" aria-live="polite"></turbo-frame>), turbo_frame_tag(record, "comments")
   end
 
   test "model frame nested withing another model frame" do
     record = Article.new(id: 1)
     nested_record = Comment.new
 
-    assert_dom_equal %(<turbo-frame id="article_1_new_comment"></turbo-frame>), turbo_frame_tag(record, nested_record)
+    assert_dom_equal %(<turbo-frame id="article_1_new_comment" aria-live="polite"></turbo-frame>), turbo_frame_tag(record, nested_record)
   end
 
   test "block style" do
-    assert_dom_equal(%(<turbo-frame id="tray"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
+    assert_dom_equal(%(<turbo-frame id="tray" aria-live="polite"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
   end
 end


### PR DESCRIPTION
For accessibility, there is an `aria-live` attribute that tells screen readers that a region of the page is "live" and how to announce updates for screen readers.

Right now it is up to the developer to manually enter the `aria-live` attribute when using the frames helper tag.

I propose we introduce `aria-live="polite"` as a sensible default and make accessibility a priority.

* [MDN docs on aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)