### PR TITLE
Add the `turbo_stream.empty` method

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -154,6 +154,21 @@ class Turbo::Streams::TagBuilder
     action_all :update, targets, content, **rendering, &block
   end
 
+  # Empty the <tt>target</tt> in the dom by removing its content. Example:
+  #
+  #   <%= turbo_stream.empty Article.new %>
+  #   <%= turbo_stream.empty "new_article" %>
+  def empty(target)
+    action :update, target, ""
+  end
+
+  # Empty the <tt>targets</tt> in the dom by removing their content. Example:
+  #
+  #   <%= turbo_stream.empty_all ".item" %>
+  def empty_all(targets)
+    action_all :update, targets, ""
+  end
+
   # Append to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
   # rendering result determined by the <tt>rendering</tt> keyword arguments, the content in the block,
   # or the rendering of the content as a record. Examples:

--- a/test/dummy/app/views/messages/show.turbo_stream.erb
+++ b/test/dummy/app/views/messages/show.turbo_stream.erb
@@ -7,3 +7,4 @@
 <%= turbo_stream.append "messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
 <%= turbo_stream.prepend "messages", @message %>
 <%= turbo_stream.prepend "messages", partial: "messages/message", locals: { message: Message.new(id: 5, content: "OLLA!") } %>
+<%= turbo_stream.empty "new_message" %>

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -28,6 +28,7 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
       <turbo-stream action="append" target="messages"><template>#{render(message_5)}</template></turbo-stream>
       <turbo-stream action="prepend" target="messages"><template>#{render(message_1)}</template></turbo-stream>
       <turbo-stream action="prepend" target="messages"><template>#{render(message_5)}</template></turbo-stream>
+      <turbo-stream action="update" target="new_message"><template></template></turbo-stream>
     HTML
   end
 


### PR DESCRIPTION
We often need to update a part of the DOM with an empty content. It is the case for example when we submit a form with valid attributes, then we want to empty the content of the form and add the created resource to a list on the page.

This PR adds syntactic sugar so that the two following expressions are equivalent, but the second one has a nicer API:

```rb
turbo_stream.update Article.new, ""
turbo_stream.empty Article.new
```