### PR TITLE
Add support for broadcasting rendering objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,5 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
   gem 'sqlite3'
+  gem 'view_component'
 end

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -83,6 +83,10 @@ module Turbo::Streams::Broadcasts
 
   private
     def render_format(format, **rendering)
-      ApplicationController.render(formats: [ format ], **rendering)
+      if rendering[:object]
+        ApplicationController.render(rendering[:object], layout: false, formats: [ format ])
+      else
+        ApplicationController.render(**rendering, formats: [ format ])
+      end
     end
 end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -26,8 +26,8 @@
 # and finally prepend the result of that partial rendering to the target identified with the dom id "clearances"
 # (which is derived by default from the plural model name of the model, but can be overwritten).
 #
-# You can also choose to render html instead of a partial inside of a broadcast
-# you do this by passing the html: option to any broadcast method that accepts the **rendering argument
+# You can also choose to render html or a renderable object instead of a partial inside of a broadcast
+# you do this by passing the html: or object: option to any broadcast method that accepts the **rendering argument
 # 
 #   class Message < ApplicationRecord
 #     belongs_to :user

--- a/test/dummy/app/components/messages_count_component.rb
+++ b/test/dummy/app/components/messages_count_component.rb
@@ -1,0 +1,9 @@
+class MessagesCountComponent < ViewComponent::Base
+  def initialize(count:)
+    @count = count
+  end
+
+  def call
+    "#{@count} messages sent from component"
+  end
+end

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -27,6 +27,18 @@ class BroadcastsTest < ApplicationSystemTestCase
     assert_selector("#message-count", text: Message.count, wait: 10)
   end
 
+  test "New messages update the message count with component" do
+    visit messages_path
+    wait_for_subscriber
+
+    assert_text "Messages"
+    message = Message.create(content: "A new message")
+
+    message.broadcast_update_to(:messages, target: "message-count",
+      object: MessagesCountComponent.new(count: Message.count))
+    assert_selector("#message-count", text: "#{Message.count} messages sent from component", wait: 10)
+  end
+
   test "Users::Profile broadcasts Turbo Streams" do
     visit users_profiles_path
     wait_for_subscriber


### PR DESCRIPTION
Rails supports [rendering of objects](https://edgeguides.rubyonrails.org/layouts_and_rendering.html#rendering-objects) such as [ViewComponents](https://github.com/github/view_component), but this support doesn't seem to be available in Turbo. This is just a stake in the sand for exploring the option to render an `object` in addition to `html` and `partial`.

This should allow for the following API call:

```ruby
message.broadcast_update_to(:messages, target: "message-count",
  object: MessagesCountComponent.new(count: Message.count))
```

where `MessagesCountComponent` is a supported Rails rendering object such as a ViewComponent. 