### PR TITLE
Enhance provided Drive helpers to allow controlling `cache` and `visit` meta tags

### DIFF
--- a/app/helpers/turbo/drive_helper.rb
+++ b/app/helpers/turbo/drive_helper.rb
@@ -1,6 +1,5 @@
 module Turbo::DriveHelper
-  # Pages that are more likely than not to be a cache miss can skip turbo cache to avoid visual jitter.
-  # Note: This requires a +yield :head+ provision in the application layout.
+  # Note: These helpers require a +yield :head+ provision in the layout.
   #
   # ==== Example
   #
@@ -10,7 +9,21 @@ module Turbo::DriveHelper
   #   # app/views/trays/index.html.erb
   #   <% turbo_exempts_page_from_cache %>
   #   <p>Page that shouldn't be cached by Turbo</p>
+
+  # Pages that are more likely than not to be a cache miss can skip turbo cache to avoid visual jitter.
+  # Cannot be used along with +turbo_exempts_page_from_preview+.
   def turbo_exempts_page_from_cache
-    provide :head, %(<meta name="turbo-cache-control" content="no-cache">).html_safe
+    provide :head, tag.meta(name: "turbo-cache-control", content: "no-cache")
+  end
+
+  # Specify that a cached version of the page should not be shown as a preview during an application visit.
+  # Cannot be used along with +turbo_exempts_page_from_cache+.
+  def turbo_exempts_page_from_preview
+    provide :head, tag.meta(name: "turbo-cache-control", content: "no-preview")
+  end
+
+  # Force the page, when loaded by Turbo, to be cause a full page reload.
+  def turbo_page_requires_reload
+    provide :head, tag.meta(name: "turbo-visit-control", content: "reload")
   end
 end

--- a/test/drive/drive_helper_test.rb
+++ b/test/drive/drive_helper_test.rb
@@ -5,4 +5,9 @@ class Turbo::DriveHelperTest < ActionDispatch::IntegrationTest
     get trays_path
     assert_match(/<meta name="turbo-cache-control" content="no-cache">/, @response.body)
   end
+
+  test "requiring reload" do
+    get trays_path
+    assert_match(/<meta name="turbo-visit-control" content="reload">/, @response.body)
+  end
 end

--- a/test/dummy/app/views/trays/index.html.erb
+++ b/test/dummy/app/views/trays/index.html.erb
@@ -1,3 +1,4 @@
 <% turbo_exempts_page_from_cache %>
+<% turbo_page_requires_reload %>
 
 <p>Not in the cache!</p>


### PR DESCRIPTION
Being able to control these `<meta>` tags with helper methods has proved really valuable in a project of ours, and seems like it would be useful for others!

I've deprecated `turbo_exempts_page_from_cache` in favor of `turbo_cache_control :no_cache` as well, since they do the same thing.