### PR TITLE
Prevent html: escaping in broadcast later actions

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -35,7 +35,7 @@ module Turbo::Streams::Broadcasts
 
   def broadcast_action_to(*streamables, action:, target: nil, targets: nil, **rendering)
     broadcast_stream_to(*streamables, content: turbo_stream_action_tag(action, target: target, targets: targets, template:
-      rendering.delete(:content) || (rendering.any? ? render_format(:html, **rendering) : nil)
+      rendering.delete(:content) || rendering.delete(:html) || (rendering.any? ? render_format(:html, **rendering) : nil)
     ))
   end
 

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -89,6 +89,14 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
     assert_broadcast_on "stream", turbo_stream_action_tag("prepend", targets: ".message", template: render(options)) do
       Turbo::StreamsChannel.broadcast_action_to "stream", action: "prepend", targets: ".message", **options
     end
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("prepend", targets: ".message", template: "<span>test</span>") do
+      Turbo::StreamsChannel.broadcast_action_to "stream", action: "prepend", targets: ".message", content: "<span>test</span>"
+    end
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("prepend", targets: ".message", template: "<span>test</span>") do
+      Turbo::StreamsChannel.broadcast_action_to "stream", action: "prepend", targets: ".message", html: "<span>test</span>"
+    end
   end
 
   test "broadcasting replace later" do


### PR DESCRIPTION
[hotwire-rails documents using an `html:` argument](https://github.com/hotwired/turbo-rails/blob/43bf84a9b1d2cc78da6810b82f92be2c32c9dbfd/app/models/concerns/turbo/broadcastable.rb#L29-L30) to broadcast HTML directly, bypassing the rendering mechanism.

However, there's a catch: when using `html:` with a broadcast later action and a queue system, the `html_safe` flag of
the `html` argument might be lost in the serialization process. Specifically, the flag remains with queue backends that work in-process (like `inline` or `async`) but it's lost in others that serialize the payload to JSON (like `resque`
or `sidekiq`).

Also, `render` escapes the escapes the `html:` param when it isn't `html_safe`.

The resulting effect is that the broadcast action works fine in development, but then fails when it's deployed to a production system.

This problem[ seems to have tripped a few people](https://github.com/hotwired/turbo-rails/issues/284) already.  

The solution is giving the `html:` argument the same treatment as the existing `content:` param. This works because the we are bypassing `render` and hence there's no escaping.