### PR TITLE
Add Empty Template Tags To The Remove Action

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -2,7 +2,7 @@ module Turbo::Streams::ActionHelper
   # Creates a `turbo-stream` tag according to the passed parameters. Examples:
   #
   #   turbo_stream_action_tag "remove", target: "message_1"
-  #   # => <turbo-stream action="remove" target="message_1"></turbo-stream>
+  #   # => <turbo-stream action="remove" target="message_1"><template></template></turbo-stream>
   #
   #   turbo_stream_action_tag "replace", target: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" target="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
@@ -10,7 +10,7 @@ module Turbo::Streams::ActionHelper
   #   turbo_stream_action_tag "replace", targets: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" targets="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
   def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil)
-    template = action.to_sym == :remove ? "" : "<template>#{template}</template>"
+    template = action.to_sym == :remove ? "<template></template>" : "<template>#{template}</template>"
 
     if target = convert_to_turbo_stream_dom_id(target)
       %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -19,7 +19,7 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
     get message_path(id: 1), as: :turbo_stream
 
     assert_dom_equal <<~HTML, @response.body
-      <turbo-stream action="remove" target="message_1"></turbo-stream>
+      <turbo-stream action="remove" target="message_1"><template></template></turbo-stream>
       <turbo-stream action="replace" target="message_1"><template>#{render(message_1)}</template></turbo-stream>
       <turbo-stream action="replace" target="message_1"><template>Something else</template></turbo-stream>
       <turbo-stream action="replace" target="message_5"><template>Something fifth</template></turbo-stream>
@@ -41,7 +41,7 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
       assert_select 'template', 'Something fourth'
     end
     assert_dom_equal <<~HTML, @response.body
-      <turbo-stream action="remove" targets="#message_1"></turbo-stream>
+      <turbo-stream action="remove" targets="#message_1"><template></template></turbo-stream>
       <turbo-stream action="replace" targets="#message_1"><template>#{render(message_1)}</template></turbo-stream>
       <turbo-stream action="replace" targets="#message_1"><template>Something else</template></turbo-stream>
       <turbo-stream action="replace" targets="#message_4"><template>Something fourth</template></turbo-stream>


### PR DESCRIPTION
While using the beta version of [hot-wired/turbo](https://github.com/hotwired/turbo), it was noted that the remove action now requires a child element <template> tag. 

If this is the intended behaviour, this PR updates the turbo_stream tag helper to add in the empty <template>  tags.