### PR TITLE
Fix compatibility shim for mobile apps

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -135,7 +135,7 @@ window.Turbolinks = {
 
         // Old mobile adapters use visit.location.absoluteURL, which is not available
         // because Turbo dropped the Location class in favor of the DOM URL API
-        const adapterVisitStarted = adapter.visitStarted
+        const adapterVisitStarted = adapter.visitStarted.bind(adapter)
         adapter.visitStarted = function(visit) {
           Object.defineProperties(visit.location, {
             absoluteURL: {


### PR DESCRIPTION
This fixes an issue in the suggested compatibility shim for mobile apps,
when the adapter is handled by turbolinks-ios or turbolinks-android.
Because the reference to `adapter.visitStarted` is  stored as a
variable, when it's called again the reference to `this` is not pointing
to the adapter's `this` but to `window`.

Co-authored-by: Juan Zenón <juanzv@hey.com>