### PR TITLE
Allow additional attributes on the `turbo_stream_action_tag` helper

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -15,9 +15,9 @@ module Turbo::Streams::ActionHelper
     template = action.to_sym == :remove ? "" : tag.template(template.to_s.html_safe)
 
     if target = convert_to_turbo_stream_dom_id(target)
-      tag.turbo_stream(template, **attributes.merge(action: action, target: target).compact)
+      tag.turbo_stream(template, **attributes.merge(action: action, target: target))
     elsif targets = convert_to_turbo_stream_dom_id(targets, include_selector: true)
-      tag.turbo_stream(template, **attributes.merge(action: action, targets: targets).compact)
+      tag.turbo_stream(template, **attributes.merge(action: action, targets: targets))
     else
       raise ArgumentError, "target or targets must be supplied"
     end

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -1,4 +1,6 @@
 module Turbo::Streams::ActionHelper
+  include ActionView::Helpers::TagHelper
+
   # Creates a `turbo-stream` tag according to the passed parameters. Examples:
   #
   #   turbo_stream_action_tag "remove", target: "message_1"
@@ -9,13 +11,13 @@ module Turbo::Streams::ActionHelper
   #
   #   turbo_stream_action_tag "replace", targets: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" targets="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
-  def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil)
-    template = action.to_sym == :remove ? "" : "<template>#{template}</template>"
+  def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil, **attributes)
+    template = action.to_sym == :remove ? "" : tag.template(template.to_s.html_safe)
 
     if target = convert_to_turbo_stream_dom_id(target)
-      %(<turbo-stream action="#{action}" target="#{target}">#{template}</turbo-stream>).html_safe
+      tag.turbo_stream(template, **attributes.merge(action: action, target: target).compact)
     elsif targets = convert_to_turbo_stream_dom_id(targets, include_selector: true)
-      %(<turbo-stream action="#{action}" targets="#{targets}">#{template}</turbo-stream>).html_safe
+      tag.turbo_stream(template, **attributes.merge(action: action, targets: targets).compact)
     else
       raise ArgumentError, "target or targets must be supplied"
     end

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -15,6 +15,12 @@ class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
     assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", hello: "world", foo: "bar")
   end
 
+  test "additional nil attributes" do
+    stream = "<turbo-stream action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", hello: nil, foo: nil)
+  end
+
   test "additional boolean attributes" do
     stream = "<turbo-stream checked=\"checked\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
 

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
+  include Turbo::Streams::ActionHelper
+
+  test "no template" do
+    stream = "<turbo-stream action=\"append\" target=\"message_1\"><template></template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1")
+  end
+
+  test "additional attributes" do
+    stream = "<turbo-stream hello=\"world\" foo=\"bar\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", hello: "world", foo: "bar")
+  end
+
+  test "additional boolean attributes" do
+    stream = "<turbo-stream checked=\"checked\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", checked: true)
+  end
+
+  test "additional dashed attributes" do
+    stream = "<turbo-stream hello-world=\"foo\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", "hello-world": "foo")
+  end
+
+  # Note: The ActionView::Helpers::TagHelper doesn't convert underscored keys to dasherized attributes
+  test "additional underscore attributes" do
+    stream = "<turbo-stream hello_world=\"foo\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", hello_world: "foo")
+  end
+
+  test "additional data attributes" do
+    stream = "<turbo-stream data-value=\"foo\" data-hello-world=\"bar\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", data: { value: "foo", hello_world: "bar"})
+  end
+
+  test "additional aria attributes" do
+    stream = "<turbo-stream aria-label=\"foo\" aria-checked=\"true\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", aria: { label: "foo", checked: true })
+  end
+
+  test "additional class attribute" do
+    stream = "<turbo-stream class=\"stream\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", class: "stream")
+  end
+
+  test "additional class conditional attribute" do
+    stream = "<turbo-stream class=\"stream another-stream\" action=\"append\" target=\"message_1\"><template>Template</template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", class: { "stream": true, "another-stream": true, "no-stream": false })
+  end
+end


### PR DESCRIPTION
Turbo now supports Custom Stream Actions via https://github.com/hotwired/turbo/pull/479. In order to be able to properly use Custom Stream Actions in your application you also need to have a new server-side helper to generate the corresponding `<turbo-stream>` element.

Imagine a Custom Stream Action `console_log` which prints out a message via JavaScript's `console.log`. The action takes two arguments: the first one is the message itself and the second optional argument is the log-level.

```js
import { StreamActions } from '@hotwired/turbo'

StreamActions.console_log = function () {
  const level = this.getAttribute('level') || 'log'
  const message = this.getAttribute('message')

  console[level](message)
}
```

This Pull Requests allows to write a custom helper, like so:

```ruby
# app/helpers/custom_stream_helper.rb

module CustomStreamHelper
  def console_log(message, level = :log)
    turbo_stream_action_tag :console_log, target: "body", message: message, level: level
  end
end

Turbo::Streams::TagBuilder.prepend(CustomStreamHelper)
```

This now allows you to call `console_log` on `turbo_stream` throughout the application with:
```ruby
turbo_stream.console_log "Hello World"
```

Which produces the following payload:
```html
<turbo-stream message="Hello World" level="log" action="console_log" target="body"><template></template></turbo-stream>
```

Previously this wasn't possible because the `turbo_stream_action_tag` method wouldn't take any additional arguments.

