### PR TITLE
Allow Turbo Stream actions to be provided as keyword arguments

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -37,7 +37,7 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.remove "clearance_5" %>
   #   <%= turbo_stream.remove clearance %>
   def remove(target)
-    action :remove, target, allow_inferred_rendering: false
+    action :remove, target: target, allow_inferred_rendering: false
   end
 
   # Removes the <tt>targets</tt> from the dom. The targets can either be a CSS selector string or an object that responds to
@@ -47,7 +47,7 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.remove_all ".clearance_item" %>
   #   <%= turbo_stream.remove_all clearance %>
   def remove_all(targets)
-    action_all :remove, targets, allow_inferred_rendering: false
+    action_all :remove, targets: targets, allow_inferred_rendering: false
   end
 
   # Replace the <tt>target</tt> in the dom with either the <tt>content</tt> passed in, a rendering result determined
@@ -60,7 +60,7 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_5'>Replace the dom target identified by clearance_5</div>
   #   <% end %>
   def replace(target, content = nil, **rendering, &block)
-    action :replace, target, content, **rendering, &block
+    action :replace, target: target, content: content, **rendering, &block
   end
 
   # Replace the <tt>targets</tt> in the dom with either the <tt>content</tt> passed in, a rendering result determined
@@ -73,7 +73,7 @@ class Turbo::Streams::TagBuilder
   #     <div class='.clearance_item'>Replace the dom target identified by the class clearance_item</div>
   #   <% end %>
   def replace_all(targets, content = nil, **rendering, &block)
-    action_all :replace, targets, content, **rendering, &block
+    action_all :replace, targets: targets, content: content, **rendering, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -86,7 +86,7 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_4'>Insert before the dom target identified by clearance_5</div>
   #   <% end %>
   def before(target, content = nil, **rendering, &block)
-    action :before, target, content, **rendering, &block
+    action :before, target: target, content: content, **rendering, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -99,7 +99,7 @@ class Turbo::Streams::TagBuilder
   #     <div class='clearance_item'>Insert before the dom target identified by clearance_item</div>
   #   <% end %>
   def before_all(targets, content = nil, **rendering, &block)
-    action_all :before, targets, content, **rendering, &block
+    action_all :before, targets: targets, content: content, **rendering, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -112,7 +112,7 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_6'>Insert after the dom target identified by clearance_5</div>
   #   <% end %>
   def after(target, content = nil, **rendering, &block)
-    action :after, target, content, **rendering, &block
+    action :after, target: target, content: content, **rendering, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -125,7 +125,7 @@ class Turbo::Streams::TagBuilder
   #     <div class='clearance_item'>Insert after the dom target identified by the class clearance_item</div>
   #   <% end %>
   def after_all(targets, content = nil, **rendering, &block)
-    action_all :after, targets, content, **rendering, &block
+    action_all :after, targets: targets, content: content, **rendering, &block
   end
 
   # Update the <tt>target</tt> in the dom with either the <tt>content</tt> passed in or a rendering result determined
@@ -138,7 +138,7 @@ class Turbo::Streams::TagBuilder
   #     Update the content of the dom target identified by clearance_5
   #   <% end %>
   def update(target, content = nil, **rendering, &block)
-    action :update, target, content, **rendering, &block
+    action :update, target: target, content: content, **rendering, &block
   end
 
   # Update the <tt>targets</tt> in the dom with either the <tt>content</tt> passed in or a rendering result determined
@@ -151,7 +151,7 @@ class Turbo::Streams::TagBuilder
   #     Update the content of the dom target identified by the class clearance_item
   #   <% end %>
   def update_all(targets, content = nil, **rendering, &block)
-    action_all :update, targets, content, **rendering, &block
+    action_all :update, targets: targets, content: content, **rendering, &block
   end
 
   # Append to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -165,7 +165,7 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_5'>Append this to .clearances</div>
   #   <% end %>
   def append(target, content = nil, **rendering, &block)
-    action :append, target, content, **rendering, &block
+    action :append, target: target, content: content, **rendering, &block
   end
 
   # Append to the targets in the dom identified with <tt>targets</tt> either the <tt>content</tt> passed in or a
@@ -179,7 +179,7 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_item'>Append this to .clearances</div>
   #   <% end %>
   def append_all(targets, content = nil, **rendering, &block)
-    action_all :append, targets, content, **rendering, &block
+    action_all :append, targets: targets, content: content, **rendering, &block
   end
 
   # Prepend to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -193,7 +193,7 @@ class Turbo::Streams::TagBuilder
   #     <div id='clearance_5'>Prepend this to .clearances</div>
   #   <% end %>
   def prepend(target, content = nil, **rendering, &block)
-    action :prepend, target, content, **rendering, &block
+    action :prepend, target: target, content: content, **rendering, &block
   end
 
   # Prepend to the targets in the dom identified with <tt>targets</tt> either the <tt>content</tt> passed in or a
@@ -207,18 +207,18 @@ class Turbo::Streams::TagBuilder
   #     <div class='clearance_item'>Prepend this to .clearances</div>
   #   <% end %>
   def prepend_all(targets, content = nil, **rendering, &block)
-    action_all :prepend, targets, content, **rendering, &block
+    action_all :prepend, targets: targets, content: content, **rendering, &block
   end
 
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
-  def action(name, target, content = nil, allow_inferred_rendering: true, **rendering, &block)
+  def action(name, target: nil, content: nil, allow_inferred_rendering: true, **rendering, &block)
     template = render_template(target, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
     turbo_stream_action_tag name, target: target, template: template
   end
 
   # Send an action of the type <tt>name</tt> to <tt>targets</tt>. Options described in the concrete methods.
-  def action_all(name, targets, content = nil, allow_inferred_rendering: true, **rendering, &block)
+  def action_all(name, targets: nil, content: nil, allow_inferred_rendering: true, **rendering, &block)
     template = render_template(targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
     turbo_stream_action_tag name, targets: targets, template: template
@@ -235,8 +235,8 @@ class Turbo::Streams::TagBuilder
         @view_context.capture(&block)
       when rendering.any?
         @view_context.render(formats: [ :html ], **rendering)
-      else
-        render_record(target) if allow_inferred_rendering
+      when allow_inferred_rendering
+        render_record(target)
       end
     end
 

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -36,8 +36,10 @@ class Turbo::Streams::TagBuilder
   #
   #   <%= turbo_stream.remove "clearance_5" %>
   #   <%= turbo_stream.remove clearance %>
-  def remove(target)
-    action :remove, target: target, allow_inferred_rendering: false
+  def remove(target = nil, **kwargs)
+    target = target || kwargs[:target]
+
+    action :remove, target: target, allow_inferred_rendering: false, **kwargs
   end
 
   # Removes the <tt>targets</tt> from the dom. The targets can either be a CSS selector string or an object that responds to
@@ -46,8 +48,10 @@ class Turbo::Streams::TagBuilder
   #
   #   <%= turbo_stream.remove_all ".clearance_item" %>
   #   <%= turbo_stream.remove_all clearance %>
-  def remove_all(targets)
-    action_all :remove, targets: targets, allow_inferred_rendering: false
+  def remove_all(targets = nil, **kwargs)
+    targets = targets || kwargs[:targets]
+
+    action :remove, targets: targets, allow_inferred_rendering: false, **kwargs
   end
 
   # Replace the <tt>target</tt> in the dom with either the <tt>content</tt> passed in, a rendering result determined
@@ -59,8 +63,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.replace "clearance_5" do %>
   #     <div id='clearance_5'>Replace the dom target identified by clearance_5</div>
   #   <% end %>
-  def replace(target, content = nil, **rendering, &block)
-    action :replace, target: target, content: content, **rendering, &block
+  def replace(target = nil, content = nil, **kwargs, &block)
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
+
+    action :replace, target: target, content: content, **kwargs, &block
   end
 
   # Replace the <tt>targets</tt> in the dom with either the <tt>content</tt> passed in, a rendering result determined
@@ -72,8 +79,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.replace_all ".clearance_item" do %>
   #     <div class='.clearance_item'>Replace the dom target identified by the class clearance_item</div>
   #   <% end %>
-  def replace_all(targets, content = nil, **rendering, &block)
-    action_all :replace, targets: targets, content: content, **rendering, &block
+  def replace_all(targets = nil, content = nil, **kwargs, &block)
+    targets = targets || kwargs[:targets]
+    content = content || kwargs[:content]
+
+    action :replace, targets: targets, content: content, **kwargs, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -85,8 +95,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.before "clearance_5" do %>
   #     <div id='clearance_4'>Insert before the dom target identified by clearance_5</div>
   #   <% end %>
-  def before(target, content = nil, **rendering, &block)
-    action :before, target: target, content: content, **rendering, &block
+  def before(target = nil, content = nil, **kwargs, &block)
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
+
+    action :before, target: target, content: content, **kwargs, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -98,8 +111,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.before_all ".clearance_item" do %>
   #     <div class='clearance_item'>Insert before the dom target identified by clearance_item</div>
   #   <% end %>
-  def before_all(targets, content = nil, **rendering, &block)
-    action_all :before, targets: targets, content: content, **rendering, &block
+  def before_all(targets = nil, content = nil, **kwargs, &block)
+    targets = targets || kwargs[:targets]
+    content = content || kwargs[:content]
+
+    action :before, targets: targets, content: content, **kwargs, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -111,8 +127,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.after "clearance_5" do %>
   #     <div id='clearance_6'>Insert after the dom target identified by clearance_5</div>
   #   <% end %>
-  def after(target, content = nil, **rendering, &block)
-    action :after, target: target, content: content, **rendering, &block
+  def after(target = nil, content = nil, **kwargs, &block)
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
+
+    action :after, target: target, content: content, **kwargs, &block
   end
 
   # Insert the <tt>content</tt> passed in, a rendering result determined by the <tt>rendering</tt> keyword arguments,
@@ -124,8 +143,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.after_all "clearance_item" do %>
   #     <div class='clearance_item'>Insert after the dom target identified by the class clearance_item</div>
   #   <% end %>
-  def after_all(targets, content = nil, **rendering, &block)
-    action_all :after, targets: targets, content: content, **rendering, &block
+  def after_all(targets = nil, content = nil, **kwargs, &block)
+    targets = targets || kwargs[:targets]
+    content = content || kwargs[:content]
+
+    action :after, targets: targets, content: content, **kwargs, &block
   end
 
   # Update the <tt>target</tt> in the dom with either the <tt>content</tt> passed in or a rendering result determined
@@ -137,8 +159,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.update "clearance_5" do %>
   #     Update the content of the dom target identified by clearance_5
   #   <% end %>
-  def update(target, content = nil, **rendering, &block)
-    action :update, target: target, content: content, **rendering, &block
+  def update(target = nil, content = nil, **kwargs, &block)
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
+
+    action :update, target: target, content: content, **kwargs, &block
   end
 
   # Update the <tt>targets</tt> in the dom with either the <tt>content</tt> passed in or a rendering result determined
@@ -150,8 +175,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.update_all "clearance_item" do %>
   #     Update the content of the dom target identified by the class clearance_item
   #   <% end %>
-  def update_all(targets, content = nil, **rendering, &block)
-    action_all :update, targets: targets, content: content, **rendering, &block
+  def update_all(targets = nil, content = nil, **kwargs, &block)
+    targets = targets || kwargs[:targets]
+    content = content || kwargs[:content]
+
+    action :update, targets: targets, content: content, **kwargs, &block
   end
 
   # Append to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -164,8 +192,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.append "clearances" do %>
   #     <div id='clearance_5'>Append this to .clearances</div>
   #   <% end %>
-  def append(target, content = nil, **rendering, &block)
-    action :append, target: target, content: content, **rendering, &block
+  def append(target = nil, content = nil, **kwargs, &block)
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
+
+    action :append, target: target, content: content, **kwargs, &block
   end
 
   # Append to the targets in the dom identified with <tt>targets</tt> either the <tt>content</tt> passed in or a
@@ -178,8 +209,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.append_all ".clearances" do %>
   #     <div id='clearance_item'>Append this to .clearances</div>
   #   <% end %>
-  def append_all(targets, content = nil, **rendering, &block)
-    action_all :append, targets: targets, content: content, **rendering, &block
+  def append_all(targets = nil, content = nil, **kwargs, &block)
+    targets = targets || kwargs[:targets]
+    content = content || kwargs[:content]
+
+    action :append, targets: targets, content: content, **kwargs, &block
   end
 
   # Prepend to the target in the dom identified with <tt>target</tt> either the <tt>content</tt> passed in or a
@@ -192,8 +226,11 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.prepend "clearances" do %>
   #     <div id='clearance_5'>Prepend this to .clearances</div>
   #   <% end %>
-  def prepend(target, content = nil, **rendering, &block)
-    action :prepend, target: target, content: content, **rendering, &block
+  def prepend(target = nil, content = nil, **kwargs, &block)
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
+
+    action :prepend, target: target, content: content, **kwargs, &block
   end
 
   # Prepend to the targets in the dom identified with <tt>targets</tt> either the <tt>content</tt> passed in or a
@@ -206,37 +243,39 @@ class Turbo::Streams::TagBuilder
   #   <%= turbo_stream.prepend_all ".clearances" do %>
   #     <div class='clearance_item'>Prepend this to .clearances</div>
   #   <% end %>
-  def prepend_all(targets, content = nil, **rendering, &block)
-    action_all :prepend, targets: targets, content: content, **rendering, &block
+  def prepend_all(targets = nil, content = nil, **kwargs, &block)
+    targets = targets || kwargs[:targets]
+    content = content || kwargs[:content]
+
+    action :prepend, targets: targets, content: content, **kwargs, &block
   end
 
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
-  def action(name = nil, target = nil, content = nil, allow_inferred_rendering: true, **kwargs, &block)
-    name = name || kwargs.delete(:name)
-    target = target || kwargs.delete(:target)
-    content = content || kwargs.delete(:content)
+  def action(name = nil, target = nil, content = nil, targets: nil, allow_inferred_rendering: true, **kwargs, &block)
+    name = name || kwargs[:name]
+    target = target || kwargs[:target]
+    content = content || kwargs[:content]
 
     rendering = extract_rendering_options(**kwargs)
-    template = render_template(target, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
+    template = render_template(target || targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
-    turbo_stream_action_tag name, target: target, template: template
+    turbo_stream_action_tag name, target: target, targets: targets, template: template
   end
 
   # Send an action of the type <tt>name</tt> to <tt>targets</tt>. Options described in the concrete methods.
-  def action_all(name = nil, targets = nil, content = nil, allow_inferred_rendering: true, **kwargs, &block)
-    name = name || kwargs.delete(:name)
-    targets = targets || kwargs.delete(:targets)
-    content = content || kwargs.delete(:content)
+  def action_all(name = nil, targets = nil, content = nil, **kwargs, &block)
+    kwargs.merge!(
+      name: name || kwargs[:name],
+      targets: targets || kwargs[:targets],
+      content: content || kwargs[:content]
+    )
 
-    rendering = extract_rendering_options(**kwargs)
-    template = render_template(targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
-
-    turbo_stream_action_tag name, targets: targets, template: template
+    action(**kwargs, &block)
   end
 
   private
     def extract_rendering_options(**rendering)
-      rendering.except(:name, :target, :targets)
+      rendering.except(:name, :target, :targets, :content)
     end
 
     def render_template(target, content = nil, allow_inferred_rendering: true, **rendering, &block)

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -251,7 +251,7 @@ class Turbo::Streams::TagBuilder
   end
 
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
-  def action(name = nil, target = nil, content = nil, targets: nil, allow_inferred_rendering: true, **kwargs, &block)
+  def action(name = nil, target = nil, content = nil, targets: nil, allow_inferred_rendering: true, attributes: {}, **kwargs, &block)
     name = name || kwargs[:name]
     target = target || kwargs[:target]
     content = content || kwargs[:content]
@@ -259,7 +259,7 @@ class Turbo::Streams::TagBuilder
     rendering = extract_rendering_options(**kwargs)
     template = render_template(target || targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
-    turbo_stream_action_tag name, target: target, targets: targets, template: template
+    turbo_stream_action_tag name, target: target, targets: targets, template: template, **attributes
   end
 
   # Send an action of the type <tt>name</tt> to <tt>targets</tt>. Options described in the concrete methods.

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -211,20 +211,34 @@ class Turbo::Streams::TagBuilder
   end
 
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
-  def action(name, target: nil, content: nil, allow_inferred_rendering: true, **rendering, &block)
+  def action(name = nil, target = nil, content = nil, allow_inferred_rendering: true, **kwargs, &block)
+    name = name || kwargs.delete(:name)
+    target = target || kwargs.delete(:target)
+    content = content || kwargs.delete(:content)
+
+    rendering = extract_rendering_options(**kwargs)
     template = render_template(target, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
     turbo_stream_action_tag name, target: target, template: template
   end
 
   # Send an action of the type <tt>name</tt> to <tt>targets</tt>. Options described in the concrete methods.
-  def action_all(name, targets: nil, content: nil, allow_inferred_rendering: true, **rendering, &block)
+  def action_all(name = nil, targets = nil, content = nil, allow_inferred_rendering: true, **kwargs, &block)
+    name = name || kwargs.delete(:name)
+    targets = targets || kwargs.delete(:targets)
+    content = content || kwargs.delete(:content)
+
+    rendering = extract_rendering_options(**kwargs)
     template = render_template(targets, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)
 
     turbo_stream_action_tag name, targets: targets, template: template
   end
 
   private
+    def extract_rendering_options(**rendering)
+      rendering.except(:name, :target, :targets)
+    end
+
     def render_template(target, content = nil, allow_inferred_rendering: true, **rendering, &block)
       case
       when content.respond_to?(:render_in)

--- a/test/streams/tag_builder/after_test.rb
+++ b/test/streams/tag_builder/after_test.rb
@@ -17,6 +17,14 @@ class Turbo::Streams::TagBuilder::AfterTest < TagBuilderTestCase
     assert_dom_equal stream_all, turbo_stream.after_all("messages", content: "After")
   end
 
+  test "after with target and content as kwargs" do
+    stream_one = %(<turbo-stream action="after" target="messages"><template>After</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="after" targets="messages"><template>After</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.after(target: "messages", content: "After")
+    assert_dom_equal stream_all, turbo_stream.after(targets: "messages", content: "After")
+  end
+
   test "after with target as arg and partial kwarg" do
     stream_one = %(<turbo-stream action="after" target="messages"><template><p>After</p>
 </template></turbo-stream>)

--- a/test/streams/tag_builder/after_test.rb
+++ b/test/streams/tag_builder/after_test.rb
@@ -1,0 +1,32 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::AfterTest < TagBuilderTestCase
+  test "after with target and content as positional arguments" do
+    stream_one = %(<turbo-stream action="after" target="messages"><template>After</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="after" targets="messages"><template>After</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.after("messages", "After")
+    assert_dom_equal stream_all, turbo_stream.after_all("messages", "After")
+  end
+
+  test "after with target as arg and content as kwarg" do
+    stream_one = %(<turbo-stream action="after" target="messages"><template>After</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="after" targets="messages"><template>After</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.after("messages", content: "After")
+    assert_dom_equal stream_all, turbo_stream.after_all("messages", content: "After")
+  end
+
+  test "after with target as arg and partial kwarg" do
+    stream_one = %(<turbo-stream action="after" target="messages"><template><p>After</p>
+</template></turbo-stream>)
+
+    stream_all = %(<turbo-stream action="after" targets="messages"><template><p>After</p>
+</template></turbo-stream>)
+
+    article = Article.new(body: "After")
+
+    assert_dom_equal stream_one, turbo_stream.after("messages", partial: "articles/article", locals: { article: article })
+    assert_dom_equal stream_all, turbo_stream.after_all("messages", partial: "articles/article", locals: { article: article })
+  end
+end

--- a/test/streams/tag_builder/append_test.rb
+++ b/test/streams/tag_builder/append_test.rb
@@ -1,0 +1,31 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::AppendTest < TagBuilderTestCase
+  test "append with target and content as positional arguments" do
+    stream_one = %(<turbo-stream action="append" target="messages"><template>Append</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="append" targets="messages"><template>Append</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.append("messages", "Append")
+    assert_dom_equal stream_all, turbo_stream.append_all("messages", "Append")
+  end
+
+  test "append with target as arg and content as kwarg" do
+    stream_one = %(<turbo-stream action="append" target="messages"><template>Append</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="append" targets="messages"><template>Append</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.append("messages", content: "Append")
+    assert_dom_equal stream_all, turbo_stream.append_all("messages", content: "Append")
+  end
+
+  test "append with target as arg and partial kwarg" do
+    stream_one = %(<turbo-stream action="append" target="messages"><template><p>Append</p>
+</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="append" targets="messages"><template><p>Append</p>
+</template></turbo-stream>)
+
+    article = Article.new(body: "Append")
+
+    assert_dom_equal stream_one, turbo_stream.append("messages", partial: "articles/article", locals: { article: article })
+    assert_dom_equal stream_all, turbo_stream.append_all("messages", partial: "articles/article", locals: { article: article })
+  end
+end

--- a/test/streams/tag_builder/append_test.rb
+++ b/test/streams/tag_builder/append_test.rb
@@ -17,6 +17,14 @@ class Turbo::Streams::TagBuilder::AppendTest < TagBuilderTestCase
     assert_dom_equal stream_all, turbo_stream.append_all("messages", content: "Append")
   end
 
+  test "append with target and content as kwargs" do
+    stream_one = %(<turbo-stream action="append" target="messages"><template>Append</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="append" targets="messages"><template>Append</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.append(target: "messages", content: "Append")
+    assert_dom_equal stream_all, turbo_stream.append(targets: "messages", content: "Append")
+  end
+
   test "append with target as arg and partial kwarg" do
     stream_one = %(<turbo-stream action="append" target="messages"><template><p>Append</p>
 </template></turbo-stream>)

--- a/test/streams/tag_builder/before_test.rb
+++ b/test/streams/tag_builder/before_test.rb
@@ -1,0 +1,31 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::BeforeTest < TagBuilderTestCase
+  test "before with target and content as positional arguments" do
+    stream_one = %(<turbo-stream action="before" target="messages"><template>Before</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="before" targets="messages"><template>Before</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.before("messages", "Before")
+    assert_dom_equal stream_all, turbo_stream.before_all("messages", "Before")
+  end
+
+  test "before with target as arg and content as kwarg" do
+    stream_one = %(<turbo-stream action="before" target="messages"><template>Before</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="before" targets="messages"><template>Before</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.before("messages", content: "Before")
+    assert_dom_equal stream_all, turbo_stream.before_all("messages", content: "Before")
+  end
+
+  test "before with target as arg and partial kwarg" do
+    stream_one = %(<turbo-stream action="before" target="messages"><template><p>Before</p>
+</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="before" targets="messages"><template><p>Before</p>
+</template></turbo-stream>)
+
+    article = Article.new(body: "Before")
+
+    assert_dom_equal stream_one, turbo_stream.before("messages", partial: "articles/article", locals: { article: article })
+    assert_dom_equal stream_all, turbo_stream.before_all("messages", partial: "articles/article", locals: { article: article })
+  end
+end

--- a/test/streams/tag_builder/before_test.rb
+++ b/test/streams/tag_builder/before_test.rb
@@ -17,6 +17,14 @@ class Turbo::Streams::TagBuilder::BeforeTest < TagBuilderTestCase
     assert_dom_equal stream_all, turbo_stream.before_all("messages", content: "Before")
   end
 
+  test "before with target and content as kwarg" do
+    stream_one = %(<turbo-stream action="before" target="messages"><template>Before</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="before" targets="messages"><template>Before</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.before(target: "messages", content: "Before")
+    assert_dom_equal stream_all, turbo_stream.before(targets: "messages", content: "Before")
+  end
+
   test "before with target as arg and partial kwarg" do
     stream_one = %(<turbo-stream action="before" target="messages"><template><p>Before</p>
 </template></turbo-stream>)

--- a/test/streams/tag_builder/prepend_test.rb
+++ b/test/streams/tag_builder/prepend_test.rb
@@ -1,0 +1,31 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::PrependTest < TagBuilderTestCase
+  test "prepend with target and content as positional arguments" do
+    stream_one = %(<turbo-stream action="prepend" target="messages"><template>Prepend</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="prepend" targets="messages"><template>Prepend</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.prepend("messages", "Prepend")
+    assert_dom_equal stream_all, turbo_stream.prepend_all("messages", "Prepend")
+  end
+
+  test "prepend with target as arg and content as kwarg" do
+    stream_one = %(<turbo-stream action="prepend" target="messages"><template>Prepend</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="prepend" targets="messages"><template>Prepend</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.prepend("messages", content: "Prepend")
+    assert_dom_equal stream_all, turbo_stream.prepend_all("messages", content: "Prepend")
+  end
+
+  test "prepend with target as arg and partial kwarg" do
+    stream_one = %(<turbo-stream action="prepend" target="messages"><template><p>Prepend</p>
+</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="prepend" targets="messages"><template><p>Prepend</p>
+</template></turbo-stream>)
+
+    article = Article.new(body: "Prepend")
+
+    assert_dom_equal stream_one, turbo_stream.prepend("messages", partial: "articles/article", locals: { article: article })
+    assert_dom_equal stream_all, turbo_stream.prepend_all("messages", partial: "articles/article", locals: { article: article })
+  end
+end

--- a/test/streams/tag_builder/prepend_test.rb
+++ b/test/streams/tag_builder/prepend_test.rb
@@ -17,6 +17,14 @@ class Turbo::Streams::TagBuilder::PrependTest < TagBuilderTestCase
     assert_dom_equal stream_all, turbo_stream.prepend_all("messages", content: "Prepend")
   end
 
+  test "prepend with target and content as kwarg" do
+    stream_one = %(<turbo-stream action="prepend" target="messages"><template>Prepend</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="prepend" targets="messages"><template>Prepend</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.prepend(target: "messages", content: "Prepend")
+    assert_dom_equal stream_all, turbo_stream.prepend(targets: "messages", content: "Prepend")
+  end
+
   test "prepend with target as arg and partial kwarg" do
     stream_one = %(<turbo-stream action="prepend" target="messages"><template><p>Prepend</p>
 </template></turbo-stream>)

--- a/test/streams/tag_builder/remove_test.rb
+++ b/test/streams/tag_builder/remove_test.rb
@@ -1,0 +1,11 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::RemoveTest < TagBuilderTestCase
+  test "remove with target as positional argument" do
+    stream_one = %(<turbo-stream action="remove" target="messages"></turbo-stream>)
+    stream_all = %(<turbo-stream action="remove" targets="messages"></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.remove("messages")
+    assert_dom_equal stream_all, turbo_stream.remove_all("messages")
+  end
+end

--- a/test/streams/tag_builder/remove_test.rb
+++ b/test/streams/tag_builder/remove_test.rb
@@ -8,4 +8,12 @@ class Turbo::Streams::TagBuilder::RemoveTest < TagBuilderTestCase
     assert_dom_equal stream_one, turbo_stream.remove("messages")
     assert_dom_equal stream_all, turbo_stream.remove_all("messages")
   end
+
+  test "remove with target and content as kwarg" do
+    stream_one = %(<turbo-stream action="remove" target="messages"></template></turbo-stream>)
+    stream_all = %(<turbo-stream action="remove" targets="messages"></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.remove(target: "messages")
+    assert_dom_equal stream_all, turbo_stream.remove(targets: "messages")
+  end
 end

--- a/test/streams/tag_builder/replace_test.rb
+++ b/test/streams/tag_builder/replace_test.rb
@@ -17,6 +17,14 @@ class Turbo::Streams::TagBuilder::ReplaceTest < TagBuilderTestCase
     assert_dom_equal stream_all, turbo_stream.replace_all("messages", content: "Replace")
   end
 
+  test "replace with target and content as kwarg" do
+    stream_one = %(<turbo-stream action="replace" target="messages"><template>Replace</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="replace" targets="messages"><template>Replace</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.replace(target: "messages", content: "Replace")
+    assert_dom_equal stream_all, turbo_stream.replace(targets: "messages", content: "Replace")
+  end
+
   test "replace with target as arg and partial kwarg" do
     stream_one = %(<turbo-stream action="replace" target="messages"><template><p>Replace</p>
 </template></turbo-stream>)

--- a/test/streams/tag_builder/replace_test.rb
+++ b/test/streams/tag_builder/replace_test.rb
@@ -1,0 +1,31 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::ReplaceTest < TagBuilderTestCase
+  test "replace with target and content as positional arguments" do
+    stream_one = %(<turbo-stream action="replace" target="messages"><template>Replace</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="replace" targets="messages"><template>Replace</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.replace("messages", "Replace")
+    assert_dom_equal stream_all, turbo_stream.replace_all("messages", "Replace")
+  end
+
+  test "replace with target as arg and content as kwarg" do
+    stream_one = %(<turbo-stream action="replace" target="messages"><template>Replace</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="replace" targets="messages"><template>Replace</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.replace("messages", content: "Replace")
+    assert_dom_equal stream_all, turbo_stream.replace_all("messages", content: "Replace")
+  end
+
+  test "replace with target as arg and partial kwarg" do
+    stream_one = %(<turbo-stream action="replace" target="messages"><template><p>Replace</p>
+</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="replace" targets="messages"><template><p>Replace</p>
+</template></turbo-stream>)
+
+    article = Article.new(body: "Replace")
+
+    assert_dom_equal stream_one, turbo_stream.replace("messages", partial: "articles/article", locals: { article: article })
+    assert_dom_equal stream_all, turbo_stream.replace_all("messages", partial: "articles/article", locals: { article: article })
+  end
+end

--- a/test/streams/tag_builder/update_test.rb
+++ b/test/streams/tag_builder/update_test.rb
@@ -1,0 +1,31 @@
+require "tag_builder_test_case"
+
+class Turbo::Streams::TagBuilder::UpdateTest < TagBuilderTestCase
+  test "update with target and content as positional arguments" do
+    stream_one = %(<turbo-stream action="update" target="messages"><template>Update</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="update" targets="messages"><template>Update</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.update("messages", "Update")
+    assert_dom_equal stream_all, turbo_stream.update_all("messages", "Update")
+  end
+
+  test "update with target as arg and content as kwarg" do
+    stream_one = %(<turbo-stream action="update" target="messages"><template>Update</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="update" targets="messages"><template>Update</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.update("messages", content: "Update")
+    assert_dom_equal stream_all, turbo_stream.update_all("messages", content: "Update")
+  end
+
+  test "update with target as arg and partial kwarg" do
+    stream_one = %(<turbo-stream action="update" target="messages"><template><p>Update</p>
+</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="update" targets="messages"><template><p>Update</p>
+</template></turbo-stream>)
+
+    article = Article.new(body: "Update")
+
+    assert_dom_equal stream_one, turbo_stream.update("messages", partial: "articles/article", locals: { article: article })
+    assert_dom_equal stream_all, turbo_stream.update_all("messages", partial: "articles/article", locals: { article: article })
+  end
+end

--- a/test/streams/tag_builder/update_test.rb
+++ b/test/streams/tag_builder/update_test.rb
@@ -17,6 +17,14 @@ class Turbo::Streams::TagBuilder::UpdateTest < TagBuilderTestCase
     assert_dom_equal stream_all, turbo_stream.update_all("messages", content: "Update")
   end
 
+  test "update with target and content as kwarg" do
+    stream_one = %(<turbo-stream action="update" target="messages"><template>Update</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="update" targets="messages"><template>Update</template></turbo-stream>)
+
+    assert_dom_equal stream_one, turbo_stream.update(target: "messages", content: "Update")
+    assert_dom_equal stream_all, turbo_stream.update(targets: "messages", content: "Update")
+  end
+
   test "update with target as arg and partial kwarg" do
     stream_one = %(<turbo-stream action="update" target="messages"><template><p>Update</p>
 </template></turbo-stream>)

--- a/test/streams/tag_builder_test.rb
+++ b/test/streams/tag_builder_test.rb
@@ -64,6 +64,12 @@ class Turbo::TagBuilderTest < TagBuilderTestCase
     assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", "Custom Content")
   end
 
+  test "action with additional attributes" do
+    stream = %(<turbo-stream class="stream" data-controller="example" action="custom_action" target="custom_target"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action("custom_action", "custom_target", content: "Custom Content", attributes: { class: "stream", data: { controller: "example" } })
+  end
+
   test "action_all with name and targets as args and content as kwarg" do
     stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
 
@@ -104,5 +110,11 @@ class Turbo::TagBuilderTest < TagBuilderTestCase
     stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
 
     assert_equal stream, turbo_stream.action_all(name: "custom_action", target: "custom_target", targets: "not_used_target")
+  end
+
+  test "action_all with additional attributes" do
+    stream = %(<turbo-stream class="stream" data-controller="example" action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", content: "Custom Content", attributes: { class: "stream", data: { controller: "example" } })
   end
 end

--- a/test/streams/tag_builder_test.rb
+++ b/test/streams/tag_builder_test.rb
@@ -1,0 +1,87 @@
+require "tag_builder_test_case"
+
+class Turbo::TagBuilderTest < TagBuilderTestCase
+  test "action with name and target as args" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action("custom_action", "custom_target")
+  end
+
+  test "action with name, target and content as args" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action("custom_action", "custom_target", "Custom Content")
+  end
+
+  test "action with name and target as args and content as kwarg" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action("custom_action", "custom_target", content: "Custom Content")
+  end
+
+  test "action with name as arg and target as kwarg" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action("custom_action", target: "custom_target")
+  end
+
+  test "action with name and targets as kwargs" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action(name: "custom_action", target: "custom_target")
+  end
+
+  test "action with name, targets and content as kwargs" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action(name: "custom_action", target: "custom_target", content: "Custom Content")
+  end
+
+  test "action should use args over kwargs if both are provided" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action("custom_action", "custom_target", name: "not_used_action", target: "not_used_target")
+  end
+
+  test "action_all with name and targets as args" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets")
+  end
+
+  test "action_all with name, targets and content as args" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", "Custom Content")
+  end
+
+  test "action_all with name and targets as args and content as kwarg" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", content: "Custom Content")
+  end
+
+  test "action_all with name as arg and targets as kwarg" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all("custom_action", targets: "custom_targets")
+  end
+
+  test "action_all with name and targets as kwargs" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all(name: "custom_action", targets: "custom_targets")
+  end
+
+  test "action_all with name targets and content as kwargs" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all(name: "custom_action", targets: "custom_targets", content: "Custom Content")
+  end
+
+  test "action_all should use args over kwargs if both are provided" do
+    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", name: "not_used_action", targets: "not_used_target")
+  end
+end

--- a/test/streams/tag_builder_test.rb
+++ b/test/streams/tag_builder_test.rb
@@ -1,6 +1,9 @@
 require "tag_builder_test_case"
 
 class Turbo::TagBuilderTest < TagBuilderTestCase
+
+  # action
+
   test "action with name and target as args" do
     stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
 
@@ -19,22 +22,20 @@ class Turbo::TagBuilderTest < TagBuilderTestCase
     assert_equal stream, turbo_stream.action("custom_action", "custom_target", content: "Custom Content")
   end
 
-  test "action with name as arg and target as kwarg" do
-    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+  test "action with name as arg and target/targets as kwarg" do
+    stream_one = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+    stream_all = %(<turbo-stream action="custom_action" targets="custom_target"><template></template></turbo-stream>)
 
-    assert_equal stream, turbo_stream.action("custom_action", target: "custom_target")
+    assert_equal stream_one, turbo_stream.action("custom_action", target: "custom_target")
+    assert_equal stream_all, turbo_stream.action("custom_action", targets: "custom_target")
   end
 
-  test "action with name and targets as kwargs" do
-    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+  test "action with name, target/targets and content as kwargs" do
+    stream_one = %(<turbo-stream action="custom_action" target="custom_target"><template>Custom Content</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="custom_action" targets="custom_target"><template>Custom Content</template></turbo-stream>)
 
-    assert_equal stream, turbo_stream.action(name: "custom_action", target: "custom_target")
-  end
-
-  test "action with name, targets and content as kwargs" do
-    stream = %(<turbo-stream action="custom_action" target="custom_target"><template>Custom Content</template></turbo-stream>)
-
-    assert_equal stream, turbo_stream.action(name: "custom_action", target: "custom_target", content: "Custom Content")
+    assert_equal stream_one, turbo_stream.action(name: "custom_action", target: "custom_target", content: "Custom Content")
+    assert_equal stream_all, turbo_stream.action(name: "custom_action", targets: "custom_target", content: "Custom Content")
   end
 
   test "action should use args over kwargs if both are provided" do
@@ -42,6 +43,14 @@ class Turbo::TagBuilderTest < TagBuilderTestCase
 
     assert_equal stream, turbo_stream.action("custom_action", "custom_target", name: "not_used_action", target: "not_used_target")
   end
+
+  test "action should use target over targets kwargs if both are provided" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action(name: "custom_action", target: "custom_target", targets: "not_used_target")
+  end
+
+  # action_all
 
   test "action_all with name and targets as args" do
     stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
@@ -61,27 +70,39 @@ class Turbo::TagBuilderTest < TagBuilderTestCase
     assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", content: "Custom Content")
   end
 
-  test "action_all with name as arg and targets as kwarg" do
-    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
+  test "action_all with name as arg and target/targets as kwarg" do
+    stream_one = %(<turbo-stream action="custom_action" target="custom_targets"><template></template></turbo-stream>)
+    stream_all = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
 
-    assert_equal stream, turbo_stream.action_all("custom_action", targets: "custom_targets")
+    assert_equal stream_one, turbo_stream.action_all("custom_action", target: "custom_targets")
+    assert_equal stream_all, turbo_stream.action_all("custom_action", targets: "custom_targets")
   end
 
-  test "action_all with name and targets as kwargs" do
-    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
+  test "action_all with name and target/targets as kwargs" do
+    stream_one = %(<turbo-stream action="custom_action" target="custom_targets"><template></template></turbo-stream>)
+    stream_all = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
 
-    assert_equal stream, turbo_stream.action_all(name: "custom_action", targets: "custom_targets")
+    assert_equal stream_one, turbo_stream.action_all(name: "custom_action", target: "custom_targets")
+    assert_equal stream_all, turbo_stream.action_all(name: "custom_action", targets: "custom_targets")
   end
 
-  test "action_all with name targets and content as kwargs" do
-    stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
+  test "action_all with name target/targets and content as kwargs" do
+    stream_one = %(<turbo-stream action="custom_action" target="custom_targets"><template>Custom Content</template></turbo-stream>)
+    stream_all = %(<turbo-stream action="custom_action" targets="custom_targets"><template>Custom Content</template></turbo-stream>)
 
-    assert_equal stream, turbo_stream.action_all(name: "custom_action", targets: "custom_targets", content: "Custom Content")
+    assert_equal stream_one, turbo_stream.action_all(name: "custom_action", target: "custom_targets", content: "Custom Content")
+    assert_equal stream_all, turbo_stream.action_all(name: "custom_action", targets: "custom_targets", content: "Custom Content")
   end
 
   test "action_all should use args over kwargs if both are provided" do
     stream = %(<turbo-stream action="custom_action" targets="custom_targets"><template></template></turbo-stream>)
 
     assert_equal stream, turbo_stream.action_all("custom_action", "custom_targets", name: "not_used_action", targets: "not_used_target")
+  end
+
+  test "action_all should use target over targets kwargs if both are provided" do
+    stream = %(<turbo-stream action="custom_action" target="custom_target"><template></template></turbo-stream>)
+
+    assert_equal stream, turbo_stream.action_all(name: "custom_action", target: "custom_target", targets: "not_used_target")
   end
 end

--- a/test/tag_builder_test_case.rb
+++ b/test/tag_builder_test_case.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class TagBuilderTestCase < ActionView::TestCase
+  private
+
+  def view_context
+    @view_context ||= ApplicationController.new.view_context
+  end
+
+  def turbo_stream
+    @turbo_stream ||= Turbo::Streams::TagBuilder.new(view_context)
+  end
+end


### PR DESCRIPTION
This pull request allows methods within the `Turbo::Streams::TagBuilder` class to be used with keywords arguments. This also allows users to build helpers for custom action helpers when the `target` is not required, as seen in #373.

It also adds tests cases for all seven default actions and the `action` and `action_all` helper methods to make sure we support all possible variants.

The amount of times I've seen people struggle with the `target` and `targets` attribute is super high. I'm also running into it from time to time. I always found it confusing to have a regular action helper for `target` and a `*_all` method for `targets`.

What this pull request proposes is to use keywords argument to make it more readable and clear which attribute is being used.

```ruby
turbo_stream.append(target: "messages", content: "Append")
turbo_stream.append(targets: "messages", content: "Append")

# => <turbo-stream action="append" target="messages"><template>Append</template></turbo-stream>
# => <turbo-stream action="append" targets="messages"><template>Append</template></turbo-stream>
```

 This change will not break backwards compatibility, as it accounts for the arguments to be passed as positional or keyword arguments. So this is also still valid:

```ruby
turbo_stream.append("messages", "Append")
turbo_stream.append_all("messages", "Append")

# => <turbo-stream action="append" target="messages"><template>Append</template></turbo-stream>
# => <turbo-stream action="append" targets="messages"><template>Append</template></turbo-stream>
```

The other problem the keywords argument solve is that you don't need to remember which argument is which and in which order you need to pass them. With keywords arguments you can pass them in any order. This might not be a big issue for the default actions, but is really beneficial for custom actions.

This also helps when building your own helpers for custom action without having to [reinvent the wheel](https://github.com/marcoroth/turbo_power-rails/blob/68d58315ed4843c86418a29de9b12a06961a0006/lib/turbo_power/stream_helper.rb#L10-L18). Previously you had to do something like:
```ruby
module TurboStreamActionsHelper
  def morph(target, content, children_only = true)
    turbo_stream_action_tag(
      :morph,
      target: target,
      template: content,
      children_only: children_only
    )
  end

  def morph_all(targets, content, children_only = true)
    turbo_stream_action_tag(
      :morph,
      targets: targets,
      template: content,
      children_only: children_only
    )
  end
end
```

With this pull request you can now make use of the `action` method and also get the `target` vs `targets` for free, without having to declare two methods in your helper for the custom action. The other benefit you get from this is that you can now pass in a block for the rendering or use the rendering mechanism which are built-into the default actions. So one can now implement a helper for a custom action like this:

```ruby
module TurboStreamActionsHelper
  def morph(target: nil, targets: nil, content: nil, **kwargs, &block)
    action :morph, target: target, targets: targets, content: content, attributes: kwargs, &block)
  end
end
```

Which allows this action to be used in all variations:
```html+erb
<%= turbo_stream.morph(target: "posts", content: "Posts") %>
<%= turbo_stream.morph(targets: ".post", content: "Post") %>

<%= turbo_stream.morph(target: dom_id(@post), partial: "posts/post", locals: { post: @post } ) %>

<%= turbo_stream.morph(target: dom_id(@post)) do %>
  <h1><%= @post.title %></h1>
<% end %>
```

To achieve this previously it required quite a sophisticated helper method. This pull request really simplifies this a lot!

Related: #375