### PR TITLE
Make `target` and `targets` attributes optional for Stream actions

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -19,7 +19,7 @@ module Turbo::Streams::ActionHelper
     elsif targets = convert_to_turbo_stream_dom_id(targets, include_selector: true)
       tag.turbo_stream(template, **attributes.merge(action: action, targets: targets))
     else
-      raise ArgumentError, "target or targets must be supplied"
+      tag.turbo_stream(template, **attributes.merge(action: action))
     end
   end
 

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -63,4 +63,10 @@ class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
 
     assert_equal stream, turbo_stream_action_tag("append", target: "message_1", template: "Template", class: { "stream": true, "another-stream": true, "no-stream": false })
   end
+
+  test "renders if no 'target' and no 'targets' attributes are provided" do
+    action = assert_nothing_raised { turbo_stream_action_tag("my_custom_action") }
+
+    assert_equal "<turbo-stream action=\"my_custom_action\"><template></template></turbo-stream>", action
+  end
 end


### PR DESCRIPTION
With the introduction of Custom Stream Actions we can now create Stream Actions that not necessarily require  a `target` attribute to be present.

~~In order to keep the behaviour we need to raise an `ArgumentError` if no `target` was passed to a default stream action helper.~~

~~This Pull Request adds a constant with the default actions which require a `target` or `targets` attribute to be present. For any other action it will return a regular `<turbo-stream>` tag without the `target` attribute.~~

Edit: This Pull Request removes the check and thus makes the `target` and `targets` attributes optional for stream actions.

Related: #373 and #374 