### PR TITLE
Call `to_turbo_stream` on the object passed to the Turbo Stream renderer

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -55,11 +55,8 @@ module Turbo
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :turbo_stream do |turbo_streams_html, options|
           self.content_type = Mime[:turbo_stream] if media_type.nil?
-          if turbo_streams_html.respond_to?(:to_turbo_stream)
-            turbo_streams_html.to_turbo_stream
-          else
-            turbo_streams_html
-          end
+
+          turbo_streams_html.try(:to_turbo_stream) || turbo_streams_html
         end
       end
     end

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -55,7 +55,11 @@ module Turbo
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :turbo_stream do |turbo_streams_html, options|
           self.content_type = Mime[:turbo_stream] if media_type.nil?
-          turbo_streams_html
+          if turbo_streams_html.respond_to?(:to_turbo_stream)
+            turbo_streams_html.to_turbo_stream
+          else
+            turbo_streams_html
+          end
         end
       end
     end

--- a/test/dummy/app/controllers/streams_controller.rb
+++ b/test/dummy/app/controllers/streams_controller.rb
@@ -1,0 +1,17 @@
+class StreamObject
+  include Turbo::Streams::ActionHelper
+
+  def name
+    "Stream Object 1"
+  end
+
+  def to_turbo_stream
+    turbo_stream_action_tag(:replace, target: "stream_object_1", template: name)
+  end
+end
+
+class StreamsController < ApplicationController
+  def index
+    render turbo_stream: StreamObject.new
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   end
   resources :trays
   resources :posts
+  resources :streams
   namespace :users do
     resources :profiles
   end

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -77,4 +77,11 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
       <p>Basecamp</p></template></turbo-stream>
     HTML
   end
+
+  test "render object as turbo_stream if it responds to #to_turbo_stream" do
+    get streams_path, as: :turbo_stream
+
+    stream = "<turbo-stream action=\"replace\" target=\"stream_object_1\"><template>Stream Object 1</template></turbo-stream>"
+    assert_dom_equal stream, @response.body
+  end
 end


### PR DESCRIPTION
Currently the `turbo_stream` format in the controller action just accepts HTML in form of a string.

This Pull Requests looks if the passed object to the Turbo Stream renderer responds to `.to_turbo_stream` and if it does calls the method on it.

This allows developers to pass in any object as long as it responds to the right method, which allows for some more advanced  Turbo Stream use-cases to build out the Turbo Stream payload.