### PR TITLE
Update docs remove deprecated function

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,7 +32,7 @@ module Turbo
         }
 
         script = []
-        script << "Turbo.clearCache()"
+        script << "Turbo.cache.clear()"
         script << "Turbo.visit(#{location.to_json}, #{visit_options.to_json})"
 
         self.status = 200


### PR DESCRIPTION
### What

Replace deprecated function `Turbo.clearCache()` in upgrade doc with `Turbo.cache.clear()`

### Reference

https://turbo.hotwired.dev/reference/drive#turbo.cache.clear