### PR TITLE
Allow passing extra params to native redirect URL

### DIFF
--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -33,8 +33,10 @@ module Turbo::Native::Navigation
 
   # :nodoc:
   def turbo_native_action_or_redirect(url, action, redirect_type, options = {})
+    native_params = options.delete(:native_params) || {}
+
     if turbo_native_app?
-      redirect_to send("turbo_#{action}_historical_location_url", notice: options[:notice] || options.delete(:native_notice))
+      redirect_to send("turbo_#{action}_historical_location_url", notice: options[:notice], **native_params)
     elsif redirect_type == :back
       redirect_back fallback_location: url, **options
     else

--- a/test/dummy/app/controllers/trays_controller.rb
+++ b/test/dummy/app/controllers/trays_controller.rb
@@ -5,12 +5,13 @@ class TraysController < ApplicationController
 
   def create
     case params[:return_to]
-    when "recede_or_redirect"       then recede_or_redirect_to tray_url(id: 1)
-    when "resume_or_redirect"       then resume_or_redirect_to tray_url(id: 1)
-    when "refresh_or_redirect"      then refresh_or_redirect_to tray_url(id: 1)
-    when "recede_or_redirect_back"  then recede_or_redirect_back_or_to tray_url(id: 5)
-    when "resume_or_redirect_back"  then resume_or_redirect_back_or_to tray_url(id: 5)
-    when "refresh_or_redirect_back" then refresh_or_redirect_back_or_to tray_url(id: 5)
+    when "recede_or_redirect"               then recede_or_redirect_to tray_url(id: 1)
+    when "resume_or_redirect"               then resume_or_redirect_to tray_url(id: 1)
+    when "refresh_or_redirect"              then refresh_or_redirect_to tray_url(id: 1)
+    when "recede_or_redirect_back"          then recede_or_redirect_back_or_to tray_url(id: 5)
+    when "resume_or_redirect_back"          then resume_or_redirect_back_or_to tray_url(id: 5)
+    when "refresh_or_redirect_back"         then refresh_or_redirect_back_or_to tray_url(id: 5)
+    when "refresh_or_redirect_with_options" then refresh_or_redirect_to tray_url(id: 5), notice: "confirmed", native_params: { custom: 123 }
     else
       raise "Supply return_to to direct response"
     end

--- a/test/native/navigation_controller_test.rb
+++ b/test/native/navigation_controller_test.rb
@@ -24,6 +24,14 @@ class Turbo::Native::NavigationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "include options in URL when redirecting native app" do
+    post trays_path, params: { return_to: "refresh_or_redirect_with_options" }
+    assert_redirected_to tray_path(id: 5)
+
+    post trays_path, params: { return_to: "refresh_or_redirect_with_options" }, headers: header_for_turbo_native_app
+    assert_redirected_to send("turbo_refresh_historical_location_url", notice: "confirmed", custom: 123)
+  end
+
   test "historical location url sends text/html" do
     get turbo_refresh_historical_location_url
 


### PR DESCRIPTION
When using the various redirect helpers, we allow passing the `:notice` option to the native redirection URL as a query param. However in some cases, apps may need to pass additional query parameters as well.
    
This adds an optional `:native_params` option, which can be a hash of query params to add to the URL when redirecting on native. This option is ignored on other platforms.
    
We also drop the special-case handling of `:native_notice` here, as that can now be more consistently handled inside `:native_params`.