### PR TITLE
Parallelize test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 /node_modules
 Gemfile.lock
+*.sqlite3*

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,8 @@ end
 
 class ActiveSupport::TestCase
   include ActiveJob::TestHelper
+
+  parallelize(workers: :number_of_processors, threshold: 2)
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
In the past, the test suite has been flaky, and didn't seem to truncate tables from previous runs.

The root cause of that might be related to [rails/rails#46820][]. In the meantime, while that is resolved, this commit adds a line to [parallelize][] to the test suite, and some corresponding `.sqlite3` ignore values to the `.gitignore`.

[rails/rails#46820]: https://github.com/rails/rails/issues/46820
[parallelize]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/TestCase.html#method-c-parallelize