### PR TITLE
Reduce allocations in `turbo_stream_action_tag`

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -15,18 +15,18 @@ module Turbo::Streams::ActionHelper
     template = action.to_sym == :remove ? "" : tag.template(template.to_s.html_safe)
 
     if target = convert_to_turbo_stream_dom_id(target)
-      tag.turbo_stream(template, **attributes.merge(action: action, target: target))
+      tag.turbo_stream(template, **attributes, action: action, target: target)
     elsif targets = convert_to_turbo_stream_dom_id(targets, include_selector: true)
-      tag.turbo_stream(template, **attributes.merge(action: action, targets: targets))
+      tag.turbo_stream(template, **attributes, action: action, targets: targets)
     else
-      tag.turbo_stream(template, **attributes.merge(action: action))
+      tag.turbo_stream(template, **attributes, action: action)
     end
   end
 
   private
     def convert_to_turbo_stream_dom_id(target, include_selector: false)
       if target.respond_to?(:to_key)
-        [ ("#" if include_selector), ActionView::RecordIdentifier.dom_id(target) ].compact.join
+        "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(target)}"
       else
         target
       end


### PR DESCRIPTION
This commit eliminates a few unnecessary allocations in `turbo_stream_action_tag`:

**Benchmark**

  ```ruby
  # frozen_string_literal: true
  require "benchmark/memory"

  class Helpers
    include Turbo::Streams::ActionHelper
  end

  class Message
    include ActiveModel::API
    def to_key() = [1]
  end

  helpers = Helpers.new
  message = Message.new

  Benchmark.memory do |x|
    helpers.turbo_stream_action_tag("remove", target: message) # warmup

    x.report("turbo_stream_action_tag") do
      helpers.turbo_stream_action_tag("remove", target: message)
    end
  end
  ```

**Before**

  ```
  Calculating -------------------------------------
  turbo_stream_action_tag
                           2.554k memsize (     0.000  retained)
                          35.000  objects (     0.000  retained)
                          12.000  strings (     0.000  retained)
  ```

**After**

  ```
  Calculating -------------------------------------
  turbo_stream_action_tag
                           2.138k memsize (     0.000  retained)
                          31.000  objects (     0.000  retained)
                          12.000  strings (     0.000  retained)
  ```
