### PR TITLE
Expose `Turbo::Native::Navigation#turbo_native_app?` helper method

### DIFF
--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -4,6 +4,12 @@
 #
 # turbo-android handles these actions automatically. You are required to implement the handling on your own for turbo-ios.
 module Turbo::Native::Navigation
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :turbo_native_app?
+  end
+
   # Turbo Native applications are identified by having the string "Turbo Native" as part of their user agent.
   def turbo_native_app?
     request.user_agent.to_s.match?(/Turbo Native/)

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="<%= "turbo-native" if turbo_native_app? %>">
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
First, promote `Turbo::Native::Navigation` to be an [ActiveSupport::Concern][].

Next, expose `#turbo_native_app?` to be a view helper through a call to [helper_method][] from within the [included][] block.

[ActiveSupport::Concern]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/Concern.html
[helper_method]: https://edgeapi.rubyonrails.org/classes/AbstractController/Helpers/ClassMethods.html#method-i-helper_method
[included]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/Concern.html#method-i-included