### PR TITLE
Force CI execution to be sequential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
     env:
       RAILS_VERSION: "${{ matrix.rails-version }}"
+      PARALLEL_WORKERS: 1
 
     name: ${{ format('Tests (Ruby {0}, Rails {1})', matrix.ruby-version, matrix.rails-version) }}
     runs-on: ubuntu-latest
@@ -32,6 +33,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
+          rubygems: 3.3.13
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 

--- a/test/dummy/.gitignore
+++ b/test/dummy/.gitignore
@@ -1,3 +1,3 @@
 *.log
-*.sqlite3
+*.sqlite3*
 tmp/*

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,8 @@ end
 
 class ActiveSupport::TestCase
   include ActiveJob::TestHelper
+
+  parallelize workers: :number_of_processors
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
In the past, the test suite has been flaky, and didn't seem to truncate tables from previous runs.

To attempt to resolve that issue, add a [parallelize][] configuration line to our `ActiveSupport::TestCase`, then force a single sequential test execution in CI by setting `PARALLEL_WORKERS=1`.

[parallelize]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/TestCase.html#method-c-parallelize