### PR TITLE
Install `cuprite`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ end
 group :test do
   gem 'capybara'
   gem 'rexml'
-  gem 'selenium-webdriver'
-  gem 'webdrivers'
+  gem 'cuprite', '~> 0.9', require: 'capybara/cuprite'
   gem 'sqlite3'
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,19 +1,7 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
-
-  def assert_no_javascript_errors
-    before = page.driver.browser.logs.get(:browser)
-
-    yield
-
-    logs = page.driver.browser.logs.get(:browser) - before
-    errors = logs.select { |log| /severe/i.match?(log.level) }
-    error_messages = errors.map(&:message)
-
-    assert_equal [], error_messages
-  end
+  driven_by :cuprite, using: :chrome, screen_size: [1400, 1400], options: { js_errors: true }
 end
 
 Capybara.configure do |config|

--- a/test/system/form_submissions_test.rb
+++ b/test/system/form_submissions_test.rb
@@ -6,9 +6,7 @@ class FormSubmissionsTest < ApplicationSystemTestCase
 
     visit edit_article_path(article.id)
 
-    assert_no_javascript_errors do
-      click_on "articles#index"
-    end
+    click_on "articles#index"
   end
 
   test "form submission method is encoded as _method" do


### PR DESCRIPTION
Execute System Tests through the CDP Protocol via [cuprite][].

This commit installs a dependency on [cuprite@~>0.9][] so that the `js_errors:` option is available. It was removed in subsequent releases, but its presence suits Turbo Rails well, since any JavaScript errors introduced by `turbo-rails.js` should fail the suite.

[cuprite]: https://github.com/rubycdp/cuprite
[cuprite@~>0.9]: https://github.com/rubycdp/cuprite/tree/v0.9#customization