### PR TITLE
FIx CI issues with RubyGems, add Ruby 3.2, Rails 7.0 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
           - "6.1"
           - "7.0"
           - "main"
+        include:
+          - { ruby-version: "3.2", rails-version: "7.0" }
 
         # Disabled until minitest relaxes its upper bound: https://github.com/seattlerb/minitest/pull/862
         # > minitest-5.14.2 requires ruby version < 3.1, >= 2.2, which is incompatible with the current version, ruby 3.1.0p-1
@@ -33,6 +35,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Run tests


### PR DESCRIPTION
Tests are still randomly failing, but the issues with the 'Install Ruby' step are fixed.  The change loads the 'latest' RubyGems version...

See https://github.com/MSP-Greg/turbo-rails/actions/runs/4060938008