### PR TITLE
Allow passing a `:template` option to Broadcastable methods

### DIFF
--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -36,6 +36,12 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting update to stream now with template option" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("update", target: "message_1", template: render("messages/index", layout: false)) do
+      @message.broadcast_update_to "stream", template: "messages/index"
+    end
+  end
+
   test "broadcasting update now" do
     assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("update", target: "message_1", template: render(@message)) do
       @message.broadcast_update


### PR DESCRIPTION
# Description

## Summary

This PR allows passing the `:template` option to the `**rendering` options of a `Broadcastable` method, so we can render a whole template instead of a partial.

## Rationale

Currently, we can only use `:partial`, `:html` or pass nothing (in this case `Broadcastable` calls the model's `to_partial_path` method). Meaning we're assuming that we'll always be dealing with partials or custom HTML written inline. If we rather want to render a whole template (e.g. index, show, edit, etc.), we need to resort to using `ApplicationController.render`, which is not ideal.

## Notes

When the `template` option is passed, we'll pass it down with the `layout: false` option, in order to avoid passing any unwanted elements such as `<head>`.