### PR TITLE
Allow broadcasting without rendering and broadcasting with custom attributes

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -33,9 +33,10 @@ module Turbo::Streams::Broadcasts
     broadcast_action_to(*streamables, action: :prepend, **opts)
   end
 
-  def broadcast_action_to(*streamables, action:, target: nil, targets: nil, **rendering)
+  def broadcast_action_to(*streamables, action:, target: nil, targets: nil, attributes: {}, **rendering)
     broadcast_stream_to(*streamables, content: turbo_stream_action_tag(action, target: target, targets: targets, template:
-      rendering.delete(:content) || rendering.delete(:html) || (rendering.any? ? render_format(:html, **rendering) : nil)
+      rendering.delete(:content) || rendering.delete(:html) || (rendering[:render] != false && rendering.any? ? render_format(:html, **rendering) : nil),
+      **attributes
     ))
   end
 
@@ -63,9 +64,9 @@ module Turbo::Streams::Broadcasts
     broadcast_action_later_to(*streamables, action: :prepend, **opts)
   end
 
-  def broadcast_action_later_to(*streamables, action:, target: nil, targets: nil, **rendering)
+  def broadcast_action_later_to(*streamables, action:, target: nil, targets: nil, attributes: {}, **rendering)
     Turbo::Streams::ActionBroadcastJob.perform_later \
-      stream_name_from(streamables), action: action, target: target, targets: targets, **rendering
+      stream_name_from(streamables), action: action, target: target, targets: targets, attributes: attributes, **rendering
   end
 
   def broadcast_render_to(*streamables, **rendering)

--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -2,7 +2,7 @@
 class Turbo::Streams::ActionBroadcastJob < ActiveJob::Base
   discard_on ActiveJob::DeserializationError
   
-  def perform(stream, action:, target:, **rendering)
-    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target, **rendering
+  def perform(stream, action:, target:, attributes: {}, **rendering)
+    Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target, attributes: attributes, **rendering
   end
 end

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -249,13 +249,13 @@ module Turbo::Broadcastable
   #   # Sends <turbo-stream action="prepend" target="clearances"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_action_to examiner.identity, :clearances, action: :prepend, target: "clearances"
-  def broadcast_action_to(*streamables, action:, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_action_to(*streamables, action: action, target: target, **broadcast_rendering_with_defaults(rendering))
+  def broadcast_action_to(*streamables, action:, target: broadcast_target_default, attributes: {}, **rendering)
+    Turbo::StreamsChannel.broadcast_action_to(*streamables, action: action, target: target, attributes: attributes, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_action_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_action(action, target: broadcast_target_default, **rendering)
-    broadcast_action_to self, action: action, target: target, **rendering
+  def broadcast_action(action, target: broadcast_target_default, attributes: {}, **rendering)
+    broadcast_action_to self, action: action, target: target, attributes: attributes, **rendering
   end
 
 
@@ -300,13 +300,13 @@ module Turbo::Broadcastable
   end
 
   # Same as <tt>broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
-  def broadcast_action_later_to(*streamables, action:, target: broadcast_target_default, **rendering)
-    Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, target: target, **broadcast_rendering_with_defaults(rendering))
+  def broadcast_action_later_to(*streamables, action:, target: broadcast_target_default, attributes: {}, **rendering)
+    Turbo::StreamsChannel.broadcast_action_later_to(*streamables, action: action, target: target, attributes: attributes, **broadcast_rendering_with_defaults(rendering))
   end
 
   # Same as <tt>#broadcast_action_later_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_action_later(action:, target: broadcast_target_default, **rendering)
-    broadcast_action_later_to self, action: action, target: target, **rendering
+  def broadcast_action_later(action:, target: broadcast_target_default, attributes: {}, **rendering)
+    broadcast_action_later_to self, action: action, target: target, attributes: attributes, **rendering
   end
 
   # Render a turbo stream template with this broadcastable model passed as the local variable. Example:
@@ -367,6 +367,8 @@ module Turbo::Broadcastable
           return o
         elsif o[:template] || o[:renderable]
           o[:layout] = false
+        elsif o[:render] == false
+          return o
         else
           # if none of these options are passed in, it will set a partial from #to_partial_path
           o[:partial] ||= to_partial_path

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -108,6 +108,70 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting action with attributes" do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: render(@message), "data-foo" => "bar") do
+      @message.broadcast_action "prepend", target: "messages", attributes: { "data-foo" => "bar" }
+    end
+  end
+
+  test "broadcasting action with no rendering" do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: nil) do
+      @message.broadcast_action "prepend", target: "messages", render: false
+    end
+  end
+
+  test "broadcasting action to with attributes" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("prepend", target: "messages", template: render(@message), "data-foo" => "bar") do
+      @message.broadcast_action_to "stream", action: "prepend", attributes: { "data-foo" => "bar" }
+    end
+  end
+
+  test "broadcasting action to with no rendering" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("prepend", target: "messages", template: nil) do
+      @message.broadcast_action_to "stream", action: "prepend", render: false
+    end
+  end
+
+  test "broadcasting action later to with attributes" do
+    @message.save!
+    
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: render(@message), "data-foo" => "bar") do
+      perform_enqueued_jobs do
+        @message.broadcast_action_later_to @message, action: "prepend", target: "messages", attributes: { "data-foo" => "bar" }
+      end
+    end
+  end
+
+  test "broadcasting action later to with no rendering" do
+    @message.save!
+
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: nil) do
+      perform_enqueued_jobs do
+        @message.broadcast_action_later_to @message, action: "prepend", target: "messages", render: false
+      end
+    end
+  end
+
+  test "broadcasting action later with attributes" do
+    @message.save!
+
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: render(@message), "data-foo" => "bar") do
+      perform_enqueued_jobs do
+        @message.broadcast_action_later action: "prepend", target: "messages", attributes: { "data-foo" => "bar" }
+      end
+    end
+  end
+
+  test "broadcasting action later with no rendering" do
+    @message.save!
+    
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("prepend", target: "messages", template: nil) do
+      perform_enqueued_jobs do
+        @message.broadcast_action_later action: "prepend", target: "messages", render: false
+      end
+    end
+  end
+
   test "render correct local name in partial for namespaced models" do
     @profile = Users::Profile.new(id: 1, name: "Ryan")
     assert_broadcast_on @profile.to_param, turbo_stream_action_tag("replace", target: "users_profile_1", template: "<p>Ryan</p>\n") do

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -1,6 +1,8 @@
 require "application_system_test_case"
 
 class BroadcastsTest < ApplicationSystemTestCase
+  include ActiveJob::TestHelper
+
   test "Message broadcasts Turbo Streams" do
     visit messages_path
     wait_for_stream_to_be_connected
@@ -22,19 +24,80 @@ class BroadcastsTest < ApplicationSystemTestCase
   test "Message broadcasts with renderable: render option" do
     visit messages_path
     wait_for_stream_to_be_connected
-
+  
     assert_broadcasts_text "Test message", to: :messages do |text, target|
       Message.create(content: "Ignored").broadcast_append_to(target, renderable: MessageComponent.new(text))
     end
   end
-
+  
   test "Does not render the layout twice when passed a component" do
     visit messages_path
     wait_for_stream_to_be_connected
-
+  
     Message.create(content: "Ignored").broadcast_append_to(:messages, renderable: MessageComponent.new("test"))
-
+  
     assert_selector("title", count: 1, visible: false, text: "Dummy")
+  end
+
+  test "Message broadcasts with extra attributes to turbo stream tag" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+
+    assert_broadcasts_text "Message 1", to: :messages do |text, target|
+      Message.create(content: text).broadcast_action_to(target, action: :append, attributes: { "data-foo": "bar" })
+    end
+  end
+
+  test "Message broadcasts with correct extra attributes to turbo stream tag" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+
+    assert_forwards_turbo_stream_tag_attribute attr_key: "data-foo", attr_value: "bar", to: :messages do |attr_key, attr_value, target|
+      Message.create(content: text).broadcast_action_to(target, action: :test, attributes: { attr_key => attr_value })
+    end
+  end
+
+  test "Message broadcasts with no rendering" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+
+    assert_forwards_turbo_stream_tag_attribute attr_key: "data-foo", attr_value: "bar", to: :messages do |attr_key, attr_value, target|
+      Message.create(content: text).broadcast_action_to(target, action: :test, render: false, partial: "non_existant", attributes: { attr_key => attr_value })
+    end
+  end
+
+  test "Message broadcasts later with extra attributes to turbo stream tag" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+
+    perform_enqueued_jobs do
+      assert_broadcasts_text "Message 1", to: :messages do |text, target|
+        Message.create(content: text).broadcast_action_later_to(target, action: :append, attributes: { "data-foo": "bar" })
+      end
+    end
+  end
+
+
+  test "Message broadcasts later with correct extra attributes to turbo stream tag" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+
+    perform_enqueued_jobs do
+      assert_forwards_turbo_stream_tag_attribute attr_key: "data-foo", attr_value: "bar", to: :messages do |attr_key, attr_value, target|
+        Message.create(content: text).broadcast_action_later_to(target, action: :test, attributes: { attr_key => attr_value })
+      end
+    end
+  end
+
+  test "Message broadcasts later with no rendering" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+
+    perform_enqueued_jobs do
+      assert_forwards_turbo_stream_tag_attribute attr_key: "data-foo", attr_value: "bar", to: :messages do |attr_key, attr_value, target|
+        Message.create(content: text).broadcast_action_to(target, action: :test, render: false, partial: "non_existant", attributes: { attr_key => attr_value })
+      end
+    end
   end
 
   test "Users::Profile broadcasts Turbo Streams" do
@@ -67,5 +130,21 @@ class BroadcastsTest < ApplicationSystemTestCase
     [text, to].yield_self(&block)
 
     within(:element, id: to) { assert_text text }
+  end
+
+  def assert_forwards_turbo_stream_tag_attribute(attr_key:, attr_value:, to:, &block)
+    execute_script(<<~SCRIPT)
+      Turbo.StreamActions.test = function () {
+        const attribute = this.getAttribute('#{attr_key}')
+
+        document.getElementById('#{to}').innerHTML = attribute
+      }
+    SCRIPT
+
+    within(:element, id: to) { assert_no_text attr_value }
+
+    [attr_key, attr_value, to].yield_self(&block)
+
+    within(:element, id: to) { assert_text attr_value }
   end
 end


### PR DESCRIPTION
# Description

## Key Enhancements

This PR improves the flexibility of custom Turbo Stream actions by allowing:

* Broadcasting without rendering
  * Some custom actions don't need any rendering at all because they're [custom actions](https://turbo.hotwired.dev/handbook/streams#custom-actions). 
* Enabling passing custom attributes via the `Broadcastable` concern.
  * These custom actions might need them.   

## Motivation

Thanks to the work on https://github.com/hotwired/turbo/pull/479 and https://github.com/hotwired/turbo-rails/pull/373,  custom `turbo_stream` actions can now be created. However, some limitations still exist ([See here for an example of both current limitations](https://github.com/hotwired/turbo-rails/pull/373)):

- Limited flexibility for passing extra attributes
  - Currently, extra attributes can only be passed via `turbo_stream_action_tag` and `turbo_stream`. 
- Inability to use custom actions via models (which use the `Broadcastable` concern)
  - Broadcasting custom actions to any streamable/model is not possible. It can only be done via a `turbo_stream` response on the controller or inside a view response (`.turbo_stream.erb`) for a single user.

## Example

A [custom stream action](https://turbo.hotwired.dev/handbook/streams#custom-actions) that doesn't need a template, only attributes (e.g. a toast):

```js
StreamActions.toast = function () {
  const text = this.getAttribute('text');
  const duration = Number(this.getAttribute('duration') || 3000);

  const toast = Toastify({
    text,
    duration,
  });

  toast.showToast();
};
```

Create a module with custom broadcast methods, just to encapsulate them and include them wherever we want:

```rb
module TurboBroadcastable
  def toast(text, duration: 3000)
    broadcast_action_later(
      :toast,
      render: false, # New in this PR
      attributes: {  # New in this PR
        text: 
        duration:
      }
    )
  end
end
```

Including it on `ApplicationRecord` so that we can `toast` to any model/streamable (as long as they're listening through `turbo_stream_from`.

```rb
class ApplicationRecord < ActiveRecord::Base
  include TurboBroadcastable
end
```

To be called anywhere, such as from a controller:

```rb
class WebhooksController < ApplicationController
  def create
    # ...
    Current.user.toast("Webhook received")
  end
end
```

## Notes

This change only affects `broadcast_action_` and related `action_` methods, since this is the method you'd use for custom actions. 

The default Javascript implementations for actions such as `prepend`, `append`, etc. are provided by Turbo on `StreamAction` and thus passing attributes here is unnecessary, since they won't be used.