### PR TITLE
Add `escape_turbo_frame` controller method

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -25,6 +25,17 @@ module Turbo::Frames::FrameRequest
     etag { :frame if turbo_frame_request? }
   end
 
+  class_methods do
+    # Force the page to cause a full page reload if sent in response to a frame request.
+    #
+    # Consider using `escape_turbo_frame` if you have pages that should always be shown in full, but which may be sent
+    # as the response to a frame request in certain situations. The classic example of this is where an expired session
+    # results in a redirect to a login page.
+    def escape_turbo_frame(...)
+      before_action(:escape_turbo_frame, ...)
+    end
+  end
+
   private
     def turbo_frame_request?
       turbo_frame_request_id.present?
@@ -32,5 +43,9 @@ module Turbo::Frames::FrameRequest
 
     def turbo_frame_request_id
       request.headers["Turbo-Frame"]
+    end
+
+    def escape_turbo_frame
+      @_escape_turbo_frame = true if turbo_frame_request?
     end
 end

--- a/app/views/layouts/turbo_rails/frame.html.erb
+++ b/app/views/layouts/turbo_rails/frame.html.erb
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <% turbo_page_requires_reload if @_escape_turbo_frame %>
     <%= yield :head %>
   </head>
   <body>

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -1,4 +1,6 @@
 class MessagesController < ApplicationController
+  escape_turbo_frame only: :index
+
   def show
     @message = Message.new(id: 1, content: "My message")
   end

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -45,6 +45,14 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     assert_match /#{turbo_frame_request_id}/, @response.body
   end
 
+  test "escape_turbo_frame sets the turbo-visit-control header for frame requests" do
+    get messages_path
+    assert_select "meta[name=turbo-visit-control]", count: 0
+
+    get messages_path, headers: { "Turbo-Frame" => "true" }
+    assert_select "meta[name=turbo-visit-control][content=reload]"
+  end
+
   private
     def with_prepended_view_path(path, &block)
       previous_view_paths = ApplicationController.view_paths


### PR DESCRIPTION
Add `escape_turbo_frame` controller method
    
To simplify the cases where responses might need to break out of frames, this adds an `escape_turbo_frame` method that can be used to selectively apply the reload requirement when responding to a frame request:

```ruby
class SessionsController < ApplicationController
  escape_turbo_frame only: :new
end
```
