### PR TITLE
Use Rack version < 3 on edge Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,10 @@ gem 'rake'
 gem 'byebug'
 gem 'puma'
 
+# For edge Rails, don't use Rack 3 yet.
+# Remove this when https://github.com/rails/rails/pull/46594 has merged.
+gem 'rack', '< 3'
+
 group :development, :test do
   gem 'importmap-rails'
 end


### PR DESCRIPTION
There is some test failure when running against edge Rails, due to the dependencies installing Rack 3 which is [not yet supported][1]. Pinning our Rack version prevents the failures.

Once the linked Rails PR has landed, we can remove this constraint.

[1]: https://github.com/rails/rails/pull/46594