### PR TITLE
Update Rakefile, Actions, fix warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,23 @@
 name: CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version:
-          - "2.7"
-          - "3.0"
-        rails-version:
-          - "6.1"
-          - "7.0"
-          - "main"
+        rails: [ "6.1", "7.0" ]
+        ruby: [ "2.7", "3.0", "3.1", "3.2" ]
+        allow-fail: [ false ]
         include:
-          - { ruby-version: "3.2", rails-version: "7.0" }
-
-        # Disabled until minitest relaxes its upper bound: https://github.com/seattlerb/minitest/pull/862
-        # > minitest-5.14.2 requires ruby version < 3.1, >= 2.2, which is incompatible with the current version, ruby 3.1.0p-1
-        #
-        # include:
-        #   - ruby-version: head
-        #     continue-on-error: true
+          - { ruby: "2.7",  rails: "main", allow-fail: true }
+          - { ruby: "3.2",  rails: "main", allow-fail: true }
+          - { ruby: "head", rails: "main", allow-fail: true }
 
     env:
-      RAILS_VERSION: "${{ matrix.rails-version }}"
+      RAILS_VERSION: "${{ matrix.rails }}"
 
-    name: ${{ format('Tests (Ruby {0}, Rails {1})', matrix.ruby-version, matrix.rails-version) }}
+    name: ${{ format('Tests (Ruby {0}, Rails {1})', matrix.ruby, matrix.rails) }}
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v1
@@ -34,13 +25,20 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby-version }}
+          ruby-version: ${{ matrix.ruby }}
           rubygems: latest
           bundler-cache: true
 
       - name: Run tests
-        run: |
-          bin/test test/**/*_test.rb
+        id: test
+        run: bundle exec rake TESTOPT=-vdc
+        continue-on-error: ${{ matrix.allow-fail || false }}
+
+      - name: >-
+          Test outcome: ${{ steps.test.outcome }}
+        # every step must define a `uses` or `run` key
+        run: echo NOOP
+
       - name: Fail when generated changes are not checked-in
         run: |
           git update-index --refresh

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,20 @@ load "rails/tasks/statistics.rake"
 Rake::TestTask.new do |test|
   test.libs << "test"
   test.test_files = FileList["test/**/*_test.rb"]
-  test.warning = false
 end
 
-task default: :test
+task :test_prereq do
+  puts "Installing Ruby dependencies"
+  `bundle install`
+
+  puts "Installing JavaScript dependencies"
+  `yarn install`
+
+  puts "Building JavaScript"
+  `yarn build`
+
+  puts "Preparing test database"
+  `cd test/dummy; ./bin/rails db:test:prepare; cd ../..`
+end
+
+task default: [:test_prereq, :test]

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -39,10 +39,10 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     turbo_frame_request_id = "test_frame_id"
 
     get tray_path(id: 1)
-    assert_no_match /#{turbo_frame_request_id}/, @response.body
+    assert_no_match(/#{turbo_frame_request_id}/, @response.body)
 
     get tray_path(id: 1), headers: { "Turbo-Frame" => turbo_frame_request_id }
-    assert_match /#{turbo_frame_request_id}/, @response.body
+    assert_match(/#{turbo_frame_request_id}/, @response.body)
   end
 
   private


### PR DESCRIPTION
A few changes mostly CI oriented, CI will now fail for Rails 6.1 & 7.0 jobs.  Rails main is allowed to fail, the easiest way to determine if they are failing is the workflow run page [example](https://github.com/MSP-Greg/turbo-rails/actions/runs/4139578933), the failed jobs are shown in the 'Annotations' section.

Note that Actions does not have an equivalent to 'allow-failure' that is present in Travis & Appveyor.

Commits:

**[Rakefile - add code from bin/test, fixup rake test](https://github.com/hotwired/turbo-rails/commit/11b9bfaa745900174c8b2e487065bdbc1d5970fe)** - allow running tests from Rake by adding code from bin/test

**[ci.yml - add more jobs, run tests with rake](https://github.com/hotwired/turbo-rails/commit/5d62b43cdff1e508db838d1f0da7fd8fadc8f740)** - tests now log the test name, with failures/errors logged at the end of the log.  Rails main jobs are allowed to fail.  Also, 'workflow_dispatch' is added, which allows maintainers to run the workflow on a given branch.  This can also be used in forks.  Can be helpful with intermittent failures... 

**[test/frames/frame_request_controller_test.rb - fix regex warning](https://github.com/hotwired/turbo-rails/commit/7456f297d24a1dbef4e318ab7b49eeb944ca9390)** - fix a regex parameter warning by added parenthesis.

Thought best to separate the commits, assume a `Squash and merge'