### PR TITLE
Support renderable object as turbo stream content

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -227,6 +227,8 @@ class Turbo::Streams::TagBuilder
   private
     def render_template(target, content = nil, allow_inferred_rendering: true, **rendering, &block)
       case
+      when content.respond_to?(:render_in)
+        content.render_in(@view_context, &block)
       when content
         allow_inferred_rendering ? (render_record(content) || content) : content
       when block_given?

--- a/test/dummy/app/components/notification_component.rb
+++ b/test/dummy/app/components/notification_component.rb
@@ -1,0 +1,5 @@
+class NotificationComponent
+  def render_in(view_context, &block)
+    "<div class='notification'>#{view_context.capture(&block)}</div>".html_safe
+  end
+end

--- a/test/dummy/app/controllers/notifications_controller.rb
+++ b/test/dummy/app/controllers/notifications_controller.rb
@@ -1,0 +1,7 @@
+class NotificationsController < ApplicationController
+  def create
+    respond_to do |format|
+      format.turbo_stream { render :new }
+    end
+  end
+end

--- a/test/dummy/app/views/notifications/new.turbo_stream.erb
+++ b/test/dummy/app/views/notifications/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append "notifications", NotificationComponent.new do %>
+  <p>Example notification</p>
+<% end %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   end
   resources :trays
   resources :posts
+  resources :notifications
   namespace :users do
     resources :profiles
   end

--- a/test/streams/streams_controller_test.rb
+++ b/test/streams/streams_controller_test.rb
@@ -77,4 +77,14 @@ class Turbo::StreamsControllerTest < ActionDispatch::IntegrationTest
       <p>Basecamp</p></template></turbo-stream>
     HTML
   end
+
+  test "render a renderable object" do
+    post notifications_path, as: :turbo_stream
+
+    assert_dom_equal <<~HTML.strip, @response.body
+      <turbo-stream action="append" target="notifications"><template><div class='notification'>
+        <p>Example notification</p>
+      </div></template></turbo-stream>
+    HTML
+  end
 end


### PR DESCRIPTION
Add support for _renderable_ objects as turbo stream content. Renderable objects respond to `render_in(view_context, &block)`, returning an html-safe String (an `ActiveSupport::SafeBuffer`).

### Example

```ruby
turbo_stream.append "notifications", NotificationComponent.new(@notification)
```

This will improve compatibility with [Phlex](https://www.phlex.fun), [ViewComponent](https://viewcomponent.org), and anything else that uses the _renderable_ duck type to provide object-oriented views.

### Approach

I added a case to `render_template` in the `TagBuilder` for when the `content` argument is a _renderable_, based on whether it responds to `render_in`.

I’m not sure if this was the right testing strategy — I decided to make a new example resource ("notifications") rather than modify one of the existing examples. Please let me know if you have any suggestions on how to better approach that.