### PR TITLE
Use new format instead of legacy

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default [
     input: pkg.module,
     output: {
       file: "app/assets/javascripts/turbo.min.js",
-      format: "es",
+      format: "esm",
       inlineDynamicImports: true,
       sourcemap: true
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default [
     input: pkg.module,
     output: {
       file: pkg.main,
-      format: "es",
+      format: "esm",
       inlineDynamicImports: true
     },
     plugins: [


### PR DESCRIPTION
"es" and "esm" are both formats for ECMAScript modules.

"es" is a legacy format that was used before the introduction of the "esm" format. It is a simple format that does not support all the features of modern ES modules. For example, it does not support dynamic imports.

"esm" is a newer and more advanced format that is designed to work with modern ES modules. It supports all the features of ES modules, including dynamic imports, export renaming, and export namespace objects. It is the recommended format for building modern JavaScript libraries and applications.