### PR TITLE
Add support for localized Turbo Streams broadcasts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 
 gem "rails", rails_constraint
 gem "sprockets-rails"
+gem "i18n"
 
 gem 'rake'
 gem 'byebug'

--- a/app/helpers/turbo/streams_helper.rb
+++ b/app/helpers/turbo/streams_helper.rb
@@ -50,6 +50,8 @@ module Turbo::StreamsHelper
   #   <%= turbo_stream_from "room", channel: RoomChannel, data: {room_name: "room #1"} %>
   #
   def turbo_stream_from(*streamables, **attributes)
+    streamables.push(I18n.locale) if Turbo.localized_broadcasts
+
     attributes[:channel] = attributes[:channel]&.to_s || "Turbo::StreamsChannel"
     attributes[:"signed-stream-name"] = Turbo::StreamsChannel.signed_stream_name(streamables)
 

--- a/lib/turbo-rails.rb
+++ b/lib/turbo-rails.rb
@@ -4,7 +4,19 @@ module Turbo
   extend ActiveSupport::Autoload
 
   class << self
-    attr_writer :signed_stream_verifier_key
+    attr_writer :signed_stream_verifier_key, :localized_broadcasts
+
+    def localized_broadcasts
+      @localized_broadcasts ||= false
+    end
+
+    def with_localized_broadcasts(value = true)
+      old_value = @localized_broadcasts
+      @localized_broadcasts = value
+      yield
+    ensure
+      @localized_broadcasts = old_value
+    end
 
     def signed_stream_verifier
       @signed_stream_verifier ||= ActiveSupport::MessageVerifier.new(signed_stream_verifier_key, digest: "SHA256", serializer: JSON)

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -51,6 +51,12 @@ module Turbo
       Mime::Type.register "text/vnd.turbo-stream.html", :turbo_stream
     end
 
+    initializer "turbo.localized_broadcasts" do
+      config.after_initialize do
+        Turbo.localized_broadcasts = config.turbo.localized_broadcasts
+      end
+    end
+
     initializer "turbo.renderer" do
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :turbo_stream do |turbo_streams_html, options|

--- a/test/dummy/app/views/messages/_message.turbo_stream.erb
+++ b/test/dummy/app/views/messages/_message.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.replace "message_1" do %>Goodbye!<% end %>
+<%= turbo_stream.replace "message_1" do %><%= I18n.t(".goodbye") %><% end %>

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -31,6 +31,7 @@
 
 en:
   hello: "Hello world"
+  goodbye: Goodbye!
   admin:
     companies:
       company:

--- a/test/dummy/config/locales/nb.yml
+++ b/test/dummy/config/locales/nb.yml
@@ -1,0 +1,7 @@
+nb:
+  hello: "Hei verden"
+  goodbye: Ha det!
+  admin:
+    companies:
+      company:
+        name: "Firma:"

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -204,3 +204,25 @@ class Turbo::BroadcastableCommentTest < ActionCable::Channel::TestCase
     end
   end
 end
+
+class Turbo::BroadcastableLocalizedTest < ActionCable::Channel::TestCase
+  include ActiveJob::TestHelper, Turbo::Streams::ActionHelper
+
+  setup { @message = Message.new(id: 1, content: "Hello!") }
+
+  test "broadcast render localized" do
+    Turbo.with_localized_broadcasts do
+      assert_broadcast_on [@message.to_gid_param, :nb].join(":"), turbo_stream_action_tag("replace", target: "message_1", template: "Ha det!") do
+        @message.broadcast_render
+      end
+    end
+  end
+
+  test "broadcast action localized" do
+    Turbo.with_localized_broadcasts do
+      assert_broadcast_on [@message.to_gid_param, :en].join(":"), turbo_stream_action_tag("prepend", target: "messages", template: render(@message)) do
+        @message.broadcast_action "prepend"
+      end
+    end
+  end
+end

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -210,4 +210,14 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
       Turbo::StreamsChannel.broadcast_stream_to "stream", content: "direct"
     end
   end
+
+  test "broadcasting localized render later" do
+    Turbo.with_localized_broadcasts do
+      assert_broadcast_on "stream:nb", turbo_stream_action_tag("replace", target: "message_1", template: "Ha det!") do
+        perform_enqueued_jobs do
+          Turbo::StreamsChannel.broadcast_render_later_to "stream", partial: "messages/message"
+        end
+      end
+    end
+  end
 end

--- a/test/streams/streams_helper_test.rb
+++ b/test/streams/streams_helper_test.rb
@@ -33,4 +33,19 @@ class Turbo::StreamsHelperTest < ActionView::TestCase
       turbo_stream_from("messages", channel: "NonExistentChannel", data: {payload: 1})
   end
 
+  test "with localization" do
+    Turbo.with_localized_broadcasts do
+      I18n.with_locale(:en) do
+        assert_dom_equal \
+          %(<turbo-cable-stream-source channel="LocalizedChannel" signed-stream-name="#{Turbo::StreamsChannel.signed_stream_name("messages:en")}"></turbo-cable-stream-source>),
+          turbo_stream_from("messages", channel: "LocalizedChannel")
+      end
+
+      I18n.with_locale(:nb) do
+        assert_dom_equal \
+          %(<turbo-cable-stream-source channel="LocalizedChannel" signed-stream-name="#{Turbo::StreamsChannel.signed_stream_name("messages:nb")}"></turbo-cable-stream-source>),
+          turbo_stream_from("messages", channel: "LocalizedChannel")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for broadcasting Turbo Streams in multiple locales using the I18n gem. The feature is opt-in and can be enabled by setting the `Turbo.localized_broadcasts` configuration to true.

The `broadcast_action_to` and `broadcast_render_to` methods have been updated to broadcast content in the current locale via a new private method `broadcasts_with_locale`. This method handles broadcasting the content for all available locales.

Additionally, the `turbo_stream_from` helper has been updated to include the current locale in the `streamables` when broadcasting localized streams.

Overall, I think this PR adds a useful new feature that can help developers build more powerful and localized web applications using Turbo Streams.