### PR TITLE
Document Navigation and expose methods publicly

### DIFF
--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -2,7 +2,7 @@
 # have Turbo Native clients running (see the Turbo iOS and Turbo Android projects for details), you can respond to native
 # requests with three dedicated responses: <tt>recede</tt>, <tt>resume</tt>, <tt>refresh</tt>.
 #
-# turbo-android handles these actions automatically. You are require to implement the handling on your own for turbo-ios.
+# turbo-android handles these actions automatically. You are required to implement the handling on your own for turbo-ios.
 module Turbo::Native::Navigation
   # Turbo Native applications are identified by having the string "Turbo Native" as part of their user agent.
   def turbo_native_app?

--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -1,6 +1,8 @@
 # Turbo is built to work with native navigation principles and present those alongside what's required for the web. When you
 # have Turbo Native clients running (see the Turbo iOS and Turbo Android projects for details), you can respond to native
 # requests with three dedicated responses: <tt>recede</tt>, <tt>resume</tt>, <tt>refresh</tt>.
+#
+# turbo-android handles these actions automatically. You are require to implement the handling on your own for turbo-ios.
 module Turbo::Native::Navigation
   # Turbo Native applications are identified by having the string "Turbo Native" as part of their user agent.
   def turbo_native_app?

--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -1,23 +1,26 @@
 # Turbo is built to work with native navigation principles and present those alongside what's required for the web. When you
 # have Turbo Native clients running (see the Turbo iOS and Turbo Android projects for details), you can respond to native
 # requests with three dedicated responses: <tt>recede</tt>, <tt>resume</tt>, <tt>refresh</tt>.
-#
-# FIXME: Supply full description of when we use either.
 module Turbo::Native::Navigation
-  private
-
+  # Turbo Native applications are identified by having the string "Turbo Native" as part of their user agent.
+  def turbo_native_app?
+    request.user_agent.to_s.match?(/Turbo Native/)
+  end
+  
+  # Tell the Turbo Native app to dismiss a modal (if presented) or pop a screen off of the navigation stack.
   def recede_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :recede, :to, options
   end
 
+  # Tell the Turbo Native app to ignore this navigation.
   def resume_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :resume, :to, options
   end
 
+  # Tell the Turbo Native app to refresh the current screen.
   def refresh_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :refresh, :to, options
   end
-
 
   def recede_or_redirect_back_or_to(url, **options)
     turbo_native_action_or_redirect url, :recede, :back, options
@@ -30,6 +33,8 @@ module Turbo::Native::Navigation
   def refresh_or_redirect_back_or_to(url, **options)
     turbo_native_action_or_redirect url, :refresh, :back, options
   end
+  
+  private
 
   # :nodoc:
   def turbo_native_action_or_redirect(url, action, redirect_type, options = {})
@@ -42,10 +47,5 @@ module Turbo::Native::Navigation
     else
       redirect_to url, options
     end
-  end
-
-  # Turbo Native applications are identified by having the string "Turbo Native" as part of their user agent.
-  def turbo_native_app?
-    request.user_agent.to_s.match?(/Turbo Native/)
   end
 end


### PR DESCRIPTION
This PR exposes the Turbo Native navigation helpers to be used in developer's apps. It also add some documentation on how you might want to use them.