### PR TITLE
feat: add action attribute to turbo_frame helper

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -35,10 +35,10 @@ module Turbo::FramesHelper
   #
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
   #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
-  def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
+  def turbo_frame_tag(*ids, src: nil, target: nil, action: nil, **attributes, &block)
     id = ids.map { |id| id.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(id) : id }.join("_")
     src = url_for(src) if src.present?
 
-    tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)
+    tag.turbo_frame(**attributes.merge(id: id, src: src, target: target, "data-turbo-action": action).compact, &block)
   end
 end

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -37,4 +37,10 @@ class Turbo::FramesHelperTest < ActionView::TestCase
   test "block style" do
     assert_dom_equal(%(<turbo-frame id="tray"><p>tray!</p></turbo-frame>), turbo_frame_tag("tray") { tag.p("tray!") })
   end
+
+  test "frame with action" do
+    record = Message.create(id: "1")
+
+    assert_dom_equal %(<turbo-frame src="/messages/1" id="message" data-turbo-action="advance"></turbo-frame>), turbo_frame_tag("message", src: record, action: "advance")
+  end
 end


### PR DESCRIPTION
### What is this?

Developer convenience.

### Why do I need this? 

Right now I have to type out:

```rb
turbo_frame_tag("message", src: record, "data_turbo_action": "advance")
```
....wait, did you catch the error above? 


Why should we trouble ourselves with remembering whether something is snake case or kebab case? Or waste time debugging, checking the docs?

This is a minor case of [computational compression](https://m.signalvnoise.com/conceptual-compression-means-beginners-dont-need-to-know-sql-hallelujah/).

Just pass in the action directly, and let's blaze along:

```rb
turbo_frame_tag("message", src: record, action: "advance")
```

