### PR TITLE
Fix the submitter’s formmethod not being respected when using Rails 7 #button form helper

### DIFF
--- a/app/javascript/turbo/fetch_requests.js
+++ b/app/javascript/turbo/fetch_requests.js
@@ -35,7 +35,16 @@ function determineFetchMethod(submitter, body, form) {
 
 function determineFormMethod(submitter) {
   if (submitter instanceof HTMLButtonElement || submitter instanceof HTMLInputElement) {
-    if (submitter.hasAttribute("formmethod")) {
+    // Rails 7 ActionView::Helpers::FormBuilder#button method has an override
+    // for formmethod if the button does not have name or value attributes
+    // set, which is the default. This means that if you use <%= f.button
+    // formmethod: :delete %>, it will generate a <button name="_method"
+    // value="delete" formmethod="post">. Therefore, if the submitter's name
+    // is already _method, it's value attribute already contains the desired
+    // method.
+    if (submitter.name === '_method') {
+      return submitter.value
+    } else if (submitter.hasAttribute("formmethod")) {
       return submitter.formMethod
     } else {
       return null

--- a/test/dummy/app/controllers/articles_controller.rb
+++ b/test/dummy/app/controllers/articles_controller.rb
@@ -33,6 +33,11 @@ class ArticlesController < ApplicationController
     redirect_to articles_url
   end
 
+  def destroy_all
+    Article.destroy_all
+    redirect_to articles_url, status: :see_other
+  end
+
   private
 
   def article_params

--- a/test/dummy/app/views/articles/edit.html.erb
+++ b/test/dummy/app/views/articles/edit.html.erb
@@ -10,6 +10,10 @@
 
   <button>Submit as PATCH</button>
   <button formmethod="post" formaction="<%= articles_path %>">Submit as POST</button>
+
+  <%# In Rails 7, there's an override of formaction, so `form.button formaction: destroy_all_articles_path, formmethod: :delete` would generate the HTML below. In Rails 6, the override of `formaction` does not exist yet, so we generate the HTML manually.  %>
+  <button name="_method" type="submit" formaction="<%= destroy_all_articles_path %>" formmethod="post" value="delete">Delete all articles</button>
+
 <% end %>
 
 <%= link_to "Submit as DELETE", article_path(@article.id), data: { turbo_method: :delete } %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :articles
+  resources :articles do
+    delete :destroy_all, on: :collection
+  end
   resources :messages do
     collection do
       get :section


### PR DESCRIPTION
After upgrading turbo-rails from 7.1.0 to 7.3.0, code like this broke:

```rb
<%= form_with(...) do |f| %>
  <%= f.button formaction: destroy_all_articles_path, formmethod: :delete } do %>Delete all articles<% end %>
```

Before the upgrade, turbo correctly issued a request with method `POST`, and the body containing a `_method` key with the `delete` value:

![image](https://user-images.githubusercontent.com/743879/227736169-a2ebc309-0715-48c9-8733-faa618681ba7.png)

This made Rails correctly route it with a `delete` verb on the backend. 

After the upgrade, however, the `_method` key in the body is lost:

![image](https://user-images.githubusercontent.com/743879/227736245-70b8cdff-55c4-44c8-9c9b-1c8dd6687886.png)

I could trace back this to https://github.com/hotwired/turbo-rails/pull/370/files from @seanpdoyle. 

That code carefully looks for the submitter's `formmethod` attribute. However, there's an extra piece in this puzzle: Rails 7 `ActionView::Helpers::FormBuilder#button` has an override  for `formmethod` if the submitter does not have the `name` or `value` attributes set, which is the default. 

```rb
# File actionview/lib/action_view/helpers/form_helper.rb, line 2609
def button(value = nil, options = {}, &block)
  # ommited 

  formmethod = options[:formmethod]
  if formmethod.present? && !/post|get/i.match?(formmethod) && !options.key?(:name) && !options.key?(:value)
    options.merge! formmethod: :post, name: "_method", value: formmethod
  end

  @template.button_tag(value, options)
end
```

This means that if you use <%= f.button formmethod: :delete %>, it will generate a `<button name="_method" value="delete" formmethod="post">`. 

So, on Rails 7, looking at the submitters `formmethod` is not enough, because the HTML in the page will already have swapped the `formmethod` defined by the user to `post`, setting the desired `formmethod` in the `value` field instead.

Therefore, this PR fixes the bug by checking if the submitter's name is already `_method`, in which case the submitter's `value` attribute will contain the actually desired method.

Lastly, I need help finishing the test suite. I couldn't understand exactly how to make so that the tests use the file `app/javascript/turbo/fetch_requests.js` file, because it seems to use the `app/assets/javascripts/turbo.js` file instead? And that file seems to be turbo + turbo-rails combined? Couldn't figure this one out!

@seanpdoyle Maybe you could help me finish this? Thanks in advance!

Mentioning https://github.com/hotwired/turbo/pull/564 because it's related. 