### PR TITLE
Support `target:` as Array argument

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -11,6 +11,18 @@ module Turbo::Streams::ActionHelper
   #
   #   turbo_stream_action_tag "replace", targets: "message_1", template: %(<div id="message_1">Hello!</div>)
   #   # => <turbo-stream action="replace" targets="message_1"><template><div id="message_1">Hello!</div></template></turbo-stream>
+  #
+  # The `target:` keyword option will forward `ActionView::RecordIdentifier#dom_id`-compatible arguments to
+  # `ActionView::RecordIdentifier#dom_id`
+  #
+  #   message = Message.find(1)
+  #   turbo_stream_action_tag "remove", target: message
+  #   # => <turbo-stream action="remove" target="message_1"></turbo-stream>
+  #
+  #   message = Message.find(1)
+  #   turbo_stream_action_tag "remove", target: [message, :special]
+  #   # => <turbo-stream action="remove" target="special_message_1"></turbo-stream>
+  #
   def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil, **attributes)
     template = action.to_sym == :remove ? "" : tag.template(template.to_s.html_safe)
 
@@ -25,8 +37,8 @@ module Turbo::Streams::ActionHelper
 
   private
     def convert_to_turbo_stream_dom_id(target, include_selector: false)
-      if target.respond_to?(:to_key)
-        "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(target)}"
+      if Array(target).any? { |value| value.respond_to?(:to_key) }
+        "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(*target)}"
       else
         target
       end

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -3,6 +3,22 @@ require "test_helper"
 class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
   include Turbo::Streams::ActionHelper
 
+  test "target responds to #to_key" do
+    message = Message.new(id: 1)
+
+    stream = "<turbo-stream action=\"append\" target=\"message_1\"><template></template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: message)
+  end
+
+  test "target passed as array of dom_id arguments" do
+    message = Message.new(id: 1)
+
+    stream = "<turbo-stream action=\"append\" target=\"special_message_1\"><template></template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: [message, :special])
+  end
+
   test "no template" do
     stream = "<turbo-stream action=\"append\" target=\"message_1\"><template></template></turbo-stream>"
 


### PR DESCRIPTION
Extend the `turbo_stream_action_tag` helper's support for the `target:` keyword argument so that it can forward Array arguments along to the underlying `dom_id` call.

For example, `dom_id(Message.find(1))` will render `message_1` while `dom_id(Message.find(1), :a_special_prefix)` will render `a_special_prefix_message_1` (to support [dom_id][]'s second optional `prefix` argument).

```ruby
message = Message.find(1)
turbo_stream_action_tag "remove", target: message
# => <turbo-stream action="remove" target="message_1"></turbo-stream>

message = Message.find(1)
turbo_stream_action_tag "remove", target: [message, :special]
# => <turbo-stream action="remove" target="special_message_1"></turbo-stream>
```

[dom_id]: https://edgeapi.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id