### PR TITLE
[CI] - gemfile - allow for capybara options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,13 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara'
+  kw =
+    if RUBY_VERSION.start_with? '3'
+      {git: 'https://github.com/teamcapybara/capybara.git', ref: '43e32a8495'}
+    else
+      {}
+    end
+  gem 'capybara', **kw
   gem 'rexml'
   gem 'selenium-webdriver'
   gem 'webdrivers'


### PR DESCRIPTION
Puma runs CI against the main branch here, as a 'real world' test.  I think a change in selenium-webdriver broke newer versions of capybara, which are used with Ruby 3.x.  Hence, CI broke here and in Puma.

The issue is fixed in capybara, but the fix hasn't been released.  This PR selectively allows using capybara from the repo if needed.

When capybara does a new release, `{git: 'https://github.com/teamcapybara/capybara.git', ref: '43e32a8495'}` can be replaced with `{}`.

Note that gemfiles cannot list the same gem twice, which is the reason for the logic with 'kw'.

Not sure if you're interested in this...