### PR TITLE
Make turbo_frame_tag fully compatible with dom_id

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -36,12 +36,7 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
   #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
-    id = if ids[0].respond_to?(:to_key)
-      ActionView::RecordIdentifier.dom_id(*ids)
-    else
-      ids[0]
-    end
-
+    id = ids.first.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.first
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)

--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -36,7 +36,12 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
   #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
-    id = ids.map { |id| id.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(id) : id }.join("_")
+    id = if ids[0].respond_to?(:to_key)
+      ActionView::RecordIdentifier.dom_id(*ids)
+    else
+      ids[0]
+    end
+
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -24,14 +24,7 @@ class Turbo::FramesHelperTest < ActionView::TestCase
   test "string frame nested withing a model frame" do
     record = Article.new(id: 1)
 
-    assert_dom_equal %(<turbo-frame id="article_1_comments"></turbo-frame>), turbo_frame_tag(record, "comments")
-  end
-
-  test "model frame nested withing another model frame" do
-    record = Article.new(id: 1)
-    nested_record = Comment.new
-
-    assert_dom_equal %(<turbo-frame id="article_1_new_comment"></turbo-frame>), turbo_frame_tag(record, nested_record)
+    assert_dom_equal %(<turbo-frame id="comments_article_1"></turbo-frame>), turbo_frame_tag(record, "comments")
   end
 
   test "block style" do


### PR DESCRIPTION
Ref #449 

Previously, there was an inconsistency with how turbo_frame_tag and dom_id would create ids:

```
turbo_frame_tag(Article.find(1), "comments") # => <turbo-frame id="article_1_comments" />
dom_id(Article.find(1), "comments") # => "comments_article_1"
```

This commit fixes that incompatibility by fully delegating id generation to dom_id when given a model object.

```
turbo_frame_tag(Article.find(1), "comments") # => <turbo-frame id="comments_article_1" />
dom_id(Article.find(1), "comments") # => "comments_article_1"

turbo_frame_tag("comments") # => <turbo-frame id="comments" />
```

This does break the use case of passing multiple models, but that seems like it would be better fixed in dom_id itself.