### PR TITLE
Make activejob optional

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -15,6 +15,10 @@ module Turbo
       #{root}/app/jobs
     )
 
+    initializer "turbo.no_active_job", before: :set_eager_load_paths do
+      config.eager_load_paths.delete("#{root}/app/jobs") unless defined?(ActiveJob)
+    end
+
     initializer "turbo.no_action_cable", before: :set_eager_load_paths do
       config.eager_load_paths.delete("#{root}/app/channels") unless defined?(ActionCable)
     end

--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.6.0"
 
-  s.add_dependency "activejob", ">= 6.0.0"
   s.add_dependency "actionpack", ">= 6.0.0"
   s.add_dependency "railties", ">= 6.0.0"
 


### PR DESCRIPTION
Fixes #478 

There was already precedent for optional Rails dependencies (action cable), so I followed that.

We could consider combining the two initializers at this point, but I'm not sure what we'd name it.