### PR TITLE
Convert DOM IDs before submitting ActionBroadcastJob

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -79,6 +79,8 @@ module Turbo::Streams::Broadcasts
     streamables.compact_blank!
 
     if streamables.present?
+      target = convert_to_turbo_stream_dom_id(target)
+      targets = convert_to_turbo_stream_dom_id(targets, include_selector: true)
       Turbo::Streams::ActionBroadcastJob.perform_later \
         stream_name_from(streamables), action: action, target: target, targets: targets, attributes: attributes, **rendering
     end


### PR DESCRIPTION
When broadcasting to a target with a suffix, i.e.
```ruby
target: [active_record_instance, :some_attribute]
```

The array will get passed to `ActionView::RecordIdentifier.dom_id` which turn it into something like:
`"active_record_instance_1234_some_attribute"`.

This works fine when broadcasting synchronously, but because array gets serialized into a parameter for the `ActionBroadcastJob`, it ends up forming an illegal target, something like: `"#<ActiveRecordInstance:0x00000> some_attribute"`

This seems to include a memory address so it should be pretty much guaranteed that it does not result in any predictable changes to the DOM.

This behavior difference is a bit confusing and hard to debug.

This change generates the `target` names before serializing the job parameters, to keep the behavior consistent between the regulater and `later` methods.

Behavior for existing applications may or may not change, depending on whether people expect this not to work.