### PR TITLE
Mention RubyDoc page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ import "@hotwired/turbo-rails"
 
 You can watch [the video introduction to Hotwire](https://hotwired.dev/#screencast), which focuses extensively on demonstrating Turbo in a Rails demo. Then you should familiarize yourself with [Turbo handbook](https://turbo.hotwired.dev/handbook/introduction) to understand Drive, Frames, and Streams in-depth. Finally, dive into the code documentation by starting with [`Turbo::FramesHelper`](https://github.com/hotwired/turbo-rails/blob/main/app/helpers/turbo/frames_helper.rb), [`Turbo::StreamsHelper`](https://github.com/hotwired/turbo-rails/blob/main/app/helpers/turbo/streams_helper.rb), [`Turbo::Streams::TagBuilder`](https://github.com/hotwired/turbo-rails/blob/main/app/models/turbo/streams/tag_builder.rb), and [`Turbo::Broadcastable`](https://github.com/hotwired/turbo-rails/blob/main/app/models/concerns/turbo/broadcastable.rb).
 
+### RubyDoc Documentation
+
+For the API documentation covering this gem's classes and packages, [visit the
+RubyDoc page][].
+
+[visit the RubyDoc page](https://rubydoc.info/github/hotwired/turbo-rails/main)
 
 ## Compatibility with Rails UJS
 


### PR DESCRIPTION
This gem's methods are documented with RubyDoc-compliant code comments. There is already a [RubyDoc page][] generated from these comments, but it isn't mentioned prominently.

Since this gem's isn't covered at length in the Turbo Handbook, the RubyDoc pages are less challenging to read and navigate than the application's source code.

This commit mentions the page and links to it from the README.

[RubyDoc page]: https://rubydoc.info/github/hotwired/turbo-rails/main