### PR TITLE
Use bun for installation if applicable

### DIFF
--- a/lib/install/turbo_with_bun.rb
+++ b/lib/install/turbo_with_bun.rb
@@ -1,0 +1,9 @@
+if (js_entrypoint_path = Rails.root.join("app/javascript/application.js")).exist?
+  say "Import Turbo"
+  append_to_file "app/javascript/application.js", %(import "@hotwired/turbo-rails"\n)
+else
+  say "You must import @hotwired/turbo-rails in your JavaScript entrypoint file", :red
+end
+
+say "Install Turbo"
+run "bun add @hotwired/turbo-rails"


### PR DESCRIPTION
This PR is part of an overall effort to allow Rails developers to completely use the Bun JS runtime and bundler without needing to use Node.JS and Yarn.

This gem is automatically invoked when a new rails projects is created and before this PR would always use Yarn. After this PR this gem will detect which JS bundler is being used and use the correct one so that Yarn doesn't accidentally slip into your Rails project.

I will be opening up a related PR to the stimulus-rails shortly.