### PR TITLE
Add support for bun

### DIFF
--- a/lib/install/turbo_with_node.rb
+++ b/lib/install/turbo_with_node.rb
@@ -6,4 +6,8 @@ else
 end
 
 say "Install Turbo"
-run "yarn add @hotwired/turbo-rails"
+if Rails.root.join("bun.config.js")).exist?
+  run "bun add @hotwired/turbo-rails"
+else
+  run "yarn add @hotwired/turbo-rails"
+end


### PR DESCRIPTION
If you create a new rails project with "--main --javascript bun" you end up with a yarn.lock and not a bun.lockb file.  This is because turbo-rails and stimuls are installed with yarn.