### PR TITLE
Allow broadcasting a renderable later

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -64,6 +64,11 @@ module Turbo::Streams::Broadcasts
   end
 
   def broadcast_action_later_to(*streamables, action:, target: nil, targets: nil, **rendering)
+    # Serialize the renderable object if it is present.
+    if rendering[:renderable]
+      rendering[:html] = rendering.delete(:renderable).render_in(self)
+    end
+
     Turbo::Streams::ActionBroadcastJob.perform_later \
       stream_name_from(streamables), action: action, target: target, targets: targets, **rendering
   end

--- a/test/system/broadcasts_test.rb
+++ b/test/system/broadcasts_test.rb
@@ -37,6 +37,28 @@ class BroadcastsTest < ApplicationSystemTestCase
     assert_selector("title", count: 1, visible: false, text: "Dummy")
   end
 
+  test "Message broadcast append later with renderable: render option" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+  
+    perform_enqueued_jobs do
+      assert_broadcasts_text "Test message", to: :messages do |text, target|
+        Message.create(content: "Ignored").broadcast_append_later_to(target, renderable: MessageComponent.new(text))
+      end
+    end
+  end
+  
+  test "Message broadcast prepend later with renderable: render option" do
+    visit messages_path
+    wait_for_stream_to_be_connected
+  
+    perform_enqueued_jobs do
+      assert_broadcasts_text "Test message", to: :messages do |text, target|
+        Message.create(content: "Ignored").broadcast_prepend_later_to(target, renderable: MessageComponent.new(text))
+      end
+    end
+  end
+
   test "Users::Profile broadcasts Turbo Streams" do
     visit users_profiles_path
     wait_for_stream_to_be_connected


### PR DESCRIPTION
# Description

https://github.com/hotwired/turbo-rails/pull/364 added support for passing a `renderable` to `Broadcastable` methods. However, it only added it for the synchronous methods. The asynchronous (`_later`) methods are broken because the renderable instance is not serialized.

This PR serializes the renderable before enqueueing it.