### PR TITLE
Fix unintentionally calling `to_a` on the target

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -37,8 +37,9 @@ module Turbo::Streams::ActionHelper
 
   private
     def convert_to_turbo_stream_dom_id(target, include_selector: false)
-      if Array(target).any? { |value| value.respond_to?(:to_key) }
-        "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(*target)}"
+      target_array = Array.wrap(target)
+      if target_array.any? { |value| value.respond_to?(:to_key) }
+        "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(*target_array)}"
       else
         target
       end

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -19,6 +19,16 @@ class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
     assert_equal stream, turbo_stream_action_tag("append", target: [message, :special])
   end
 
+  test "target uses custom to_a" do
+    klass = Class.new(Message) do
+      def to_a; raise "DO NOT CALL ME"; end
+      def self.name; "CustomToAClass"; end
+    end
+
+    stream = "<turbo-stream action=\"append\" target=\"new_custom_to_a_class\"><template></template></turbo-stream>"
+    assert_equal stream, turbo_stream_action_tag("append", target: klass.new)
+  end
+
   test "no template" do
     stream = "<turbo-stream action=\"append\" target=\"message_1\"><template></template></turbo-stream>"
 


### PR DESCRIPTION
The fix in #448 had some unintented consequences. We have a custom `to_a` method on one of our ActiveRecord objects which returns a set of different ActiveRecord objects. (Yes, I'm well aware this violates the Law of Least Surprise, but it was done ages ago and is now so baked into our code that extracting it would be a major undertaking.)

The current code "splats" the `target` of `turbo_stream_action_tag` to pass to the `dom_id` method. The problem is that it's assuming that the object is "array-like" - which the `Array()` method does not ensure. It uses `to_ary` or `to_a` to _return_ an array, but doesn't indicate that the object itself is in fact an array.

This PR fixes this by using `Array.wrap`, ensuring we actually have an array, and splatting the array into the method rather than the original target (which would call `to_a` again).

I wasn't able to find a contribution guideline page, so please let me know if anything else needs to be done here (do I need to create an issue?)