### PR TITLE
Restore `turbo_frame_tag` support for Array arguments

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -23,6 +23,9 @@ module Turbo::FramesHelper
   #     <div>My tray frame!</div>
   #   <% end %>
   #   # => <turbo-frame id="tray"><div>My tray frame!</div></turbo-frame>
+
+  #   <%= turbo_frame_tag [user_id, "tray"], src: tray_path(tray) %>
+  #   # => <turbo-frame id="1_tray" src="http://example.com/trays/1"></turbo-frame>
   #
   # The `turbo_frame_tag` helper will convert the arguments it receives to their
   # `dom_id` if applicable to easily generate unique ids for Turbo Frames:
@@ -36,7 +39,19 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
   #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
-    id = ids.first.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.first
+    id =
+      if ids.first.respond_to?(:to_key)
+        ActionView::RecordIdentifier.dom_id(*ids)
+      else
+        ids.map do |id|
+          if id.respond_to?(:to_key)
+            ActionView::RecordIdentifier.dom_id(*id)
+          else
+            id
+          end
+        end.join("_")
+      end
+
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -21,6 +21,12 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
   end
 
+  test "frame with Array argument" do
+    target = [1, 2, "string"]
+
+    assert_dom_equal %(<turbo-frame id="1_2_string"></turbo-frame>), turbo_frame_tag(target)
+  end
+
   test "string frame nested withing a model frame" do
     record = Article.new(id: 1)
 


### PR DESCRIPTION
Closes [#503][]

When the positional arguments to `turbo_frame_tag` respond are compatible with `dom_id` (they respond to `#to_key`), pass them to `dom_id`, otherwise, check them individually.

This approach melds the behavior introduced in [#476][] with the original support.

[#503]: https://github.com/hotwired/turbo-rails/issues/503
[#476]: https://github.com/hotwired/turbo-rails/pull/476