### PR TITLE
Revise how to disable eager loading app/channels

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -16,7 +16,15 @@ module Turbo
     )
 
     initializer "turbo.no_action_cable", before: :set_eager_load_paths do
-      config.eager_load_paths.delete("#{root}/app/channels") unless defined?(ActionCable)
+      unless defined?(ActionCable)
+        if Rails.autoloaders.zeitwerk_enabled?
+          Rails.autoloaders.once.do_not_eager_load("#{root}/app/channels")
+        else
+          # The purpose of this else clause is to support the classic autoloader
+          # in Rails 6.x applications. Can be deleted if the gem dependency is upgraded to Rails 7 or above.
+          config.eager_load_paths.delete("#{root}/app/channels")
+        end
+      end
     end
 
     # If you don't want to precompile Turbo's assets (eg. because you're using webpack),


### PR DESCRIPTION
## Background

If the parent application does not use Action Cable, `turbo-rails` prevents `app/channels` from being eager loaded, since some necessary classes do not exist.

## The root issue

The interface of `config.eager_load_paths` and friends has always been ill-defined.

For example, `config.autoload_paths` is empty, while `config.eager_load_paths` is not. This is confusing, don't you think? In any case, only _pushing_ to these collections was documented, and pushing ended up doing what it was expected, unless you also used the paths API, in which case you'd hit a long-standing bug that was [fixed in Rails 7.1.2](https://github.com/rails/rails/pull/49636).

Bottom line, deletion from those collections was not something you could rely on. It worked on this collection by pure chance, and would have no effect in others. This interface did not exist, basically. And the fix in Rails 7.1.2 not only revises the logic, but also clarifies the contract for these collections.

## The patch

In order to be able to not eager load `app/channels`, we leave that deletion for `classic` because it works and that won't change in old releases. But for applications loading with Zeitwerk, we use the interface that is documented to work.

Note that `Rails.autoloaders.zeitwerk_enabled?` still exists today, even if Zeitwerk has been the only autoloader since Rails 7. And it does so precisely for cases like this in which engines need to support multiple Rails versions.

## Testing

Unfortunately, there are no tests for this. I only tried manually. Being able to test this would need work in the test harness of `turbo-rails` itself. There is more conditional code in the initializers to be tested. You'd need different dummy apps, and for this particular case, `test/test_helper.rb` should not [assume the ActionCable constant is defined](https://github.com/hotwired/turbo-rails/blob/e44b6a98a77a0a2cc927f986a67517d73c4c9246/test/test_helper.rb#L24), or should be refactored somehow.

But that is out of the scope of this PR. This patch fixes the issue to be able to ship a new version of `turbo-rails`, and I'll leave work on an improved test harness to the Hotwire team.

Fixes #512.