### PR TITLE
Tests: rely on load hooks instead of class constants

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,14 +13,14 @@ module ActionViewTestCaseExtensions
   end
 end
 
-class ActiveSupport::TestCase
+ActiveSupport.on_load :active_support_test_case do
   include ActiveJob::TestHelper
 end
 
-class ActionDispatch::IntegrationTest
+ActiveSupport.on_load :action_dispatch_integration_test do
   include ActionViewTestCaseExtensions
 end
 
-class ActionCable::Channel::TestCase
-  include ActionViewTestCaseExtensions
+ActiveSupport.on_load :action_cable_channel do
+  ActionCable::Channel::TestCase.include ActionViewTestCaseExtensions
 end


### PR DESCRIPTION
Follow-up to [#513][]

Rely on [on_load hooks][] to extend test helpers. Despite the fact that Action Cable is an optional dependency and Action Dispatch is not, this commit replaces all `class`-style extensions with `on_load` hooks for the sake of consistency.

There isn't a hook for `ActionCable::Channel::TestCase`, so waiting for `action_cable_channel` to fire is the best that we can do.

[#513]: https://github.com/hotwired/turbo-rails/pull/513
[on_load hooks]: https://guides.rubyonrails.org/engines.html#available-load-hooks