### PR TITLE
Add actioncable dependency to gemspec

### DIFF
--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activejob", ">= 6.0.0"
   s.add_dependency "actionpack", ">= 6.0.0"
+  s.add_dependency "actioncable", ">= 6.0.0"
   s.add_dependency "railties", ">= 6.0.0"
 
   s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]


### PR DESCRIPTION
Turbo depends on ActionCable in runtime, but it's not listed in the gemspec. This is not a problem with the tests because of the Gemfile and, more generally, because ActionCable is a dependency of Rails.

While investigating a loading problem with turbo-rails and an app that didn't use ActionCable, I ran into this.