### PR TITLE
Require active support module extensions

### DIFF
--- a/lib/turbo-rails.rb
+++ b/lib/turbo-rails.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/module/attribute_accessors_per_thread"
 require "turbo/engine"
 
 module Turbo


### PR DESCRIPTION
Without this line, when rails boots thread_mattr_accessor throws an error  saying it's undefined. 

This is happening on 2.0 beta1