### PR TITLE
Fix sending created broadcasts refreshes to channels where no one listens

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -142,9 +142,11 @@ module Turbo::Broadcastable
     end
 
     # Same as <tt>#broadcasts_refreshes_to</tt>, but the designated stream for page refreshes is automatically set to
-    # the current model.
-    def broadcasts_refreshes
-      after_commit -> { broadcast_refresh_later }
+    # the current model, for creates - to the model plural name, which can be overriden by passing <tt>stream</tt>.
+    def broadcasts_refreshes(stream = model_name.plural)
+      after_create_commit  -> { broadcast_refresh_later_to(stream) }
+      after_update_commit  -> { broadcast_refresh_later }
+      after_destroy_commit -> { broadcast_refresh }
     end
 
     # All default targets will use the return of this method. Overwrite if you want something else than <tt>model_name.plural</tt>.

--- a/test/dummy/app/models/board.rb
+++ b/test/dummy/app/models/board.rb
@@ -1,5 +1,5 @@
 class Board < ApplicationRecord
-    has_many :tasks
+  has_many :tasks
 
-    broadcasts_refreshes
+  broadcasts_refreshes
 end

--- a/test/dummy/app/models/board.rb
+++ b/test/dummy/app/models/board.rb
@@ -1,0 +1,5 @@
+class Board < ApplicationRecord
+    has_many :tasks
+
+    broadcasts_refreshes
+end

--- a/test/dummy/app/models/board.rb
+++ b/test/dummy/app/models/board.rb
@@ -1,5 +1,3 @@
 class Board < ApplicationRecord
-  has_many :tasks
-
   broadcasts_refreshes
 end

--- a/test/dummy/db/migrate/20231123180958_create_boards.rb
+++ b/test/dummy/db/migrate/20231123180958_create_boards.rb
@@ -1,0 +1,9 @@
+class CreateBoards < ActiveRecord::Migration[6.1]
+  def change
+    create_table :boards do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_23_150403) do
+ActiveRecord::Schema.define(version: 2023_11_23_181306) do
 
   create_table "articles", force: :cascade do |t|
     t.text "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "boards", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
### Fixed

- In https://github.com/hotwired/turbo-rails/pull/499 a new `broadcasts_refreshes` method was added that sets up the model hooks to send broadcasts refreshes automatically. However, it repeats the same issue previously found in the `broadcasts` method (https://github.com/hotwired/turbo-rails/pull/295) where it sends the creation broadcasts to the current model's channel and defaults to, but no one will ever be listening on that. This PR allows passing a `stream` param to `broadcasts_refreshes` method, which will be used as the channel name when broadcasting refreshes on model creation and defaults to the model's plural name, similar to how the `broadcasts` method works. It also sends the broadcast refresh right away instead of later when the model is deleted.