### PR TITLE
Require AttributeAccessorsPerThread

### DIFF
--- a/lib/turbo-rails.rb
+++ b/lib/turbo-rails.rb
@@ -1,4 +1,5 @@
 require "turbo/engine"
+require "active_support/core_ext/module/attribute_accessors_per_thread"
 
 module Turbo
   extend ActiveSupport::Autoload


### PR DESCRIPTION
This is the same patch as in #508 
The PR got merged into the feature branch after the feature was merged to the main branch.

Fixes library loading error in edge Rails.

Repository reproducing the problem: https://github.com/sevos/example_rails_turbo_morph

I've tested the library with Rails 7.2 (main branch), and the library failed to load with the undefined method `thread_mattr_accessor` on `Turbo:Module` error. Locally, I fixed it by requiring the appropriate file from ActiveSupport before loading Gemfile in application.rb. This PR should fix this.