### PR TITLE
Fix unsupported `ActiveSupport::SafeBuffer` being passed to BroadcastStreamJob

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -70,7 +70,7 @@ module Turbo::Streams::Broadcasts
 
   def broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id, **opts)
     refresh_debouncer_for(*streamables, request_id: request_id).debounce do
-      Turbo::Streams::BroadcastStreamJob.perform_later stream_name_from(streamables), content: turbo_stream_refresh_tag(request_id: request_id, **opts)
+      Turbo::Streams::BroadcastStreamJob.perform_later stream_name_from(streamables), content: turbo_stream_refresh_tag(request_id: request_id, **opts).to_str
     end
   end
 


### PR DESCRIPTION
Fixes #522.