### PR TITLE
Handle empty streamable array

### DIFF
--- a/app/channels/turbo/streams/stream_name.rb
+++ b/app/channels/turbo/streams/stream_name.rb
@@ -23,6 +23,9 @@ module Turbo::Streams::StreamName
   private
     def stream_name_from(streamables)
       if streamables.is_a?(Array)
+        if streamables.compact_blank.empty?
+          raise ArgumentError, "At least one streamable must be provided. You passed #{streamables.inspect}"
+        end
         streamables.map  { |streamable| stream_name_from(streamable) }.join(":")
       else
         streamables.then { |streamable| streamable.try(:to_gid_param) || streamable.to_param }

--- a/test/broadcastable/test_helper_test.rb
+++ b/test/broadcastable/test_helper_test.rb
@@ -104,6 +104,14 @@ end
 class Turbo::Broadcastable::TestHelper::AssertTurboStreamBroadcastsTest < ActiveSupport::TestCase
   include Turbo::Broadcastable::TestHelper
 
+  test "#an exception is raised when the argument is nil" do
+    message = Message.new(id: 1)
+
+    assert_raises ArgumentError do
+      message.broadcast_replace_to nil
+    end
+  end
+
   test "#assert_turbo_stream_broadcasts passes when there is a broadcast" do
     message = Message.new(id: 1)
 


### PR DESCRIPTION
This PR originates from a difficult debugging session I had.

In my model I had a typo:

```
after_create_commit -> { broadcast_append_to @chatroom }
```

and used `@chatroom` instead of `chatroom`. This error lead to an empty `streamables` array (`[nil]`) and the broadcasting was not working.

The error symptoms were:
* the message does not appear on screen
* I look at browsers network log and I don't see any message arriving in the websocket
* I look at the logs and I spot the following:
```
[ActionCable] Broadcasting to : "<turbo-stream action=\"append\" ...
```
where you can see that the final stream name ends up being simply `:`. I had therefore an hard time to spot the issue.

This PR is very aggressive, and simply raises in such a context, maybe we would like a lighter (error message) approach? I think that if we have an empty streamables array is most probably an error.