### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ On top of accelerating web applications, Turbo was built from the ground-up to f
 
 Turbo is a language-agnostic framework written in JavaScript, but this gem builds on top of those basics to make the integration with Rails as smooth as possible. You can deliver turbo updates via model callbacks over Action Cable, respond to controller actions with native navigation or standard redirects, and render turbo frames with helpers and layout-free responses.
 
-
 ## Navigate with Turbo Drive
 
 Turbo is a continuation of the ideas from the previous [Turbolinks](https://github.com/turbolinks/turbolinks) framework, and the heart of that past approach lives on as Turbo Drive. When installed, Turbo automatically intercepts all clicks on `<a href>` links to the same domain. When you click an eligible link, Turbo prevents the browser from following it. Instead, Turbo changes the browser’s URL using the History API, requests the new page using `fetch`, and then renders the HTML response.
@@ -122,7 +121,6 @@ The `Turbo` instance is automatically assigned to `window.Turbo` upon import:
 import "@hotwired/turbo-rails"
 ```
 
-
 ## Usage
 
 You can watch [the video introduction to Hotwire](https://hotwired.dev/#screencast), which focuses extensively on demonstrating Turbo in a Rails demo. Then you should familiarize yourself with [Turbo handbook](https://turbo.hotwired.dev/handbook/introduction) to understand Drive, Frames, and Streams in-depth. Finally, dive into the code documentation by starting with [`Turbo::FramesHelper`](https://github.com/hotwired/turbo-rails/blob/main/app/helpers/turbo/frames_helper.rb), [`Turbo::StreamsHelper`](https://github.com/hotwired/turbo-rails/blob/main/app/helpers/turbo/streams_helper.rb), [`Turbo::Streams::TagBuilder`](https://github.com/hotwired/turbo-rails/blob/main/app/models/turbo/streams/tag_builder.rb), and [`Turbo::Broadcastable`](https://github.com/hotwired/turbo-rails/blob/main/app/models/concerns/turbo/broadcastable.rb).
@@ -130,6 +128,17 @@ You can watch [the video introduction to Hotwire](https://hotwired.dev/#screenca
 ### RubyDoc Documentation
 
 For the API documentation covering this gem's classes and packages, [visit the RubyDoc page](https://rubydoc.info/github/hotwired/turbo-rails/main).
+Note that this documentation is updated automatically from the main branch, so it may contain features that are not released yet.
+
+- [Turbo Drive Helpers](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/DriveHelper)
+- [Turbo Frames Helpers](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/FramesHelper)
+- [Turbo Streams View Helpers](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/StreamsHelper)
+- [Turbo Streams Broadcast Methods](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/Broadcastable)
+- [Turbo Streams Channel](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/StreamsChannel)
+- [Turbo Native Navigation](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/Native/Navigation)
+- [Turbo Test Assertions](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/TestAssertions)
+- [Turbo Integration Test Assertions](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/TestAssertions/IntegrationTestAssertions)
+- [Turbo Broadcastable Test Helper](https://rubydoc.info/github/hotwired/turbo-rails/main/Turbo/Broadcastable/TestHelper)
 
 ## Compatibility with Rails UJS
 
@@ -137,8 +146,7 @@ Turbo can coexist with Rails UJS, but you need to take a series of upgrade steps
 
 ## Testing
 
-
-The [`Turbo::TestAssertions`](./lib/turbo/test_assertions.rb) concern provides Turbo Stream test helpers that assert the presence or absence of `<turbo-stream>` elements in a rendered fragment of HTML. `Turbo::TestAssertions` are automatically included in [`ActiveSupport::TestCase`](https://edgeapi.rubyonrails.org/classes/ActiveSupport/TestCase.html) and depend on the presence of [`rails-dom-testing`](https://github.com/rails/rails-dom-testing/) assertions.
+The [`Turbo::TestAssertions`](./lib/turbo/test_assertions.rb) concern provides Turbo Stream test helpers that assert the presence or absence ofs  s  `<turbo-stream>` elements in a rendered fragment of HTML. `Turbo::TestAssertions` are automatically included in [`ActiveSaupport::TestCase`](https://edgeapi.rubyonrails.org/classes/ActiveSupport/TestCase.html) and depend on the presence of [`rails-dom-testing`](https://github.com/rails/rails-dom-testing/) assertions.
 
 The [`Turbo::TestAssertions::IntegrationTestAssertions`](./lib/turbo/test_assertions/integration_test_assertions.rb) are built on top of `Turbo::TestAssertions`, and add support for passing a `status:` keyword. They are automatically included in [`ActionDispatch::IntegrationTest`](https://edgeguides.rubyonrails.org/testing.html#integration-testing).
 
@@ -147,7 +155,6 @@ The [`Turbo::Broadcastable::TestHelper`](./lib/turbo/broadcastable/test_helper.r
 ## Development
 
 Run the tests with `./bin/test`.
-
 
 ## License
 

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -1,4 +1,4 @@
-# Provides the broadcast actions in synchronous and asynchrous form for the <tt>Turbo::StreamsChannel</tt>.
+# Provides the broadcast actions in synchronous and asynchronous form for the <tt>Turbo::StreamsChannel</tt>.
 # See <tt>Turbo::Broadcastable</tt> for the user-facing API that invokes these methods with most of the paperwork filled out already.
 #
 # Can be used directly using something like <tt>Turbo::StreamsChannel.broadcast_remove_to :entries, target: 1</tt>.

--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -5,7 +5,7 @@
 # When that header is detected by the controller, we substitute our own minimal layout in place of the
 # application-supplied layout (since we're only working on an in-page frame, thus can skip the weight of the layout). We
 # use a minimal layout, rather than avoid the layout entirely, so that it's still possible to render content into the
-# <tt>head<tt>.
+# <tt>head</tt>.
 #
 # Accordingly, we ensure that the etag for the page is changed, such that a cache for a minimal-layout request isn't
 # served on a normal request and vice versa.

--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -15,29 +15,32 @@ module Turbo::Native::Navigation
     request.user_agent.to_s.match?(/Turbo Native/)
   end
   
-  # Tell the Turbo Native app to dismiss a modal (if presented) or pop a screen off of the navigation stack.
+  # Tell the Turbo Native app to dismiss a modal (if presented) or pop a screen off of the navigation stack. Otherwise redirect to the given URL if Turbo Native is not present.
   def recede_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :recede, :to, options
   end
 
-  # Tell the Turbo Native app to ignore this navigation.
+  # Tell the Turbo Native app to ignore this navigation, otherwise redirect to the given URL if Turbo Native is not present.
   def resume_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :resume, :to, options
   end
 
-  # Tell the Turbo Native app to refresh the current screen.
+  # Tell the Turbo Native app to refresh the current screen, otherwise redirect to the given URL if Turbo Native is not present.
   def refresh_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :refresh, :to, options
   end
 
+  # Same as <tt>recede_or_redirect_to</tt> but redirects to the previous page or provided fallback location if the Turbo Native app is not present.
   def recede_or_redirect_back_or_to(url, **options)
     turbo_native_action_or_redirect url, :recede, :back, options
   end
 
+  # Same as <tt>resume_or_redirect_to</tt> but redirects to the previous page or provided fallback location if the Turbo Native app is not present.
   def resume_or_redirect_back_or_to(url, **options)
     turbo_native_action_or_redirect url, :resume, :back, options
   end
 
+  # Same as <tt>refresh_or_redirect_to</tt> but redirects to the previous page or provided fallback location if the Turbo Native app is not present.
   def refresh_or_redirect_back_or_to(url, **options)
     turbo_native_action_or_redirect url, :refresh, :back, options
   end

--- a/app/helpers/turbo/drive_helper.rb
+++ b/app/helpers/turbo/drive_helper.rb
@@ -1,22 +1,21 @@
+# Helpers to configure Turbo Drive via meta directives. They come in two
+# variants:
+#
+# The recommended option is to include +yield :head+ in the +<head>+ section
+# of the layout. Then you can use the helpers in any view.
+#
+# ==== Example
+#
+#   # app/views/application.html.erb
+#   <html><head><%= yield :head %></head><body><%= yield %></html>
+#
+#   # app/views/trays/index.html.erb
+#   <% turbo_exempts_page_from_cache %>
+#   <p>Page that shouldn't be cached by Turbo</p>
+#
+# Alternatively, you can use the +_tag+ variant of the helpers to only get the
+# HTML for the meta directive.
 module Turbo::DriveHelper
-  # Helpers to configure Turbo Drive via meta directives. They come in two
-  # variants:
-  #
-  # The recommended option is to include +yield :head+ in the +<head>+ section
-  # of the layout. Then you can use the helpers in any view.
-  #
-  # ==== Example
-  #
-  #   # app/views/application.html.erb
-  #   <html><head><%= yield :head %></head><body><%= yield %></html>
-  #
-  #   # app/views/trays/index.html.erb
-  #   <% turbo_exempts_page_from_cache %>
-  #   <p>Page that shouldn't be cached by Turbo</p>
-  #
-  # Alternatively, you can use the +_tag+ variant of the helpers to only get the
-  # HTML for the meta directive.
-
   # Pages that are more likely than not to be a cache miss can skip turbo cache to avoid visual jitter.
   # Cannot be used along with +turbo_exempts_page_from_preview+.
   def turbo_exempts_page_from_cache

--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -2,7 +2,7 @@ module Turbo::FramesHelper
   # Returns a frame tag that can either be used simply to encapsulate frame content or as a lazy-loading container that starts empty but
   # fetches the URL supplied in the +src+ attribute.
   #
-  # === Examples
+  # ==== Examples
   #
   #   <%= turbo_frame_tag "tray", src: tray_path(tray) %>
   #   # => <turbo-frame id="tray" src="http://example.com/trays/1"></turbo-frame>
@@ -27,17 +27,14 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag [user_id, "tray"], src: tray_path(tray) %>
   #   # => <turbo-frame id="1_tray" src="http://example.com/trays/1"></turbo-frame>
   #
-  # The `turbo_frame_tag` helper will convert the arguments it receives to their
-  # `dom_id` if applicable to easily generate unique ids for Turbo Frames:
+  # The +turbo_frame_tag+ helper will convert the arguments it receives to their
+  # +dom_id+ if applicable to easily generate unique ids for Turbo Frames:
   #
   #   <%= turbo_frame_tag(Article.find(1)) %>
   #   # => <turbo-frame id="article_1"></turbo-frame>
   #
   #   <%= turbo_frame_tag(Article.find(1), "comments") %>
-  #   # => <turbo-frame id="article_1_comments"></turbo-frame>
-  #
-  #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
-  #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
+  #   # => <turbo-frame id="comments_article_1"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
     id = ids.first.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.join('_')
     src = url_for(src) if src.present?

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -22,7 +22,6 @@ module Turbo::Streams::ActionHelper
   #   message = Message.find(1)
   #   turbo_stream_action_tag "remove", target: [message, :special]
   #   # => <turbo-stream action="remove" target="special_message_1"></turbo-stream>
-  #
   def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil, **attributes)
     template = action.to_sym.in?(%i[ remove refresh ]) ? "" : tag.template(template.to_s.html_safe)
 
@@ -35,6 +34,10 @@ module Turbo::Streams::ActionHelper
     end
   end
 
+  # Creates a `turbo-stream` tag with an `action="refresh"` attribute. Example:
+  #
+  #   turbo_stream_refresh_tag
+  #   # => <turbo-stream action="refresh"></turbo-stream>
   def turbo_stream_refresh_tag(request_id: Turbo.current_request_id, **attributes)
     turbo_stream_action_tag(:refresh, **{ "request-id": request_id }.compact, **attributes)
   end

--- a/app/helpers/turbo/streams_helper.rb
+++ b/app/helpers/turbo/streams_helper.rb
@@ -48,7 +48,6 @@ module Turbo::StreamsHelper
   # It is also possible to pass additional parameters to the channel by passing them through `data` attributes:
   #
   #   <%= turbo_stream_from "room", channel: RoomChannel, data: {room_name: "room #1"} %>
-  #
   def turbo_stream_from(*streamables, **attributes)
     attributes[:channel] = attributes[:channel]&.to_s || "Turbo::StreamsChannel"
     attributes[:"signed-stream-name"] = Turbo::StreamsChannel.signed_stream_name(streamables)

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -14,8 +14,8 @@
 #       end
 #   end
 #
-# This is an example from [HEY](https://hey.com), and the clearance is the model that drives
-# [the screener](https://hey.com/features/the-screener/), which gives users the power to deny first-time senders (petitioners)
+# This is an example from {HEY}[https://hey.com], and the clearance is the model that drives
+# {the screener}[https://hey.com/features/the-screener/], which gives users the power to deny first-time senders (petitioners)
 # access to their attention (as the examiner). When a new clearance is created upon receipt of an email from a first-time
 # sender, that'll trigger the call to broadcast_later, which in turn invokes <tt>broadcast_prepend_later_to</tt>.
 #
@@ -27,7 +27,7 @@
 # (which is derived by default from the plural model name of the model, but can be overwritten).
 #
 # You can also choose to render html instead of a partial inside of a broadcast
-# you do this by passing the `html:` option to any broadcast method that accepts the **rendering argument. Example:
+# you do this by passing the +html:+ option to any broadcast method that accepts the **rendering argument. Example:
 #
 #   class Message < ApplicationRecord
 #     belongs_to :user
@@ -40,8 +40,8 @@
 #       end
 #   end
 #
-# If you want to render a template instead of a partial, e.g. ('messages/index' or 'messages/show'), you can use the `template:` option.
-# Again, only to any broadcast method that accepts the `**rendering` argument. Example:
+# If you want to render a template instead of a partial, e.g. ('messages/index' or 'messages/show'), you can use the +template:+ option.
+# Again, only to any broadcast method that accepts the +**rendering+ argument. Example:
 #
 #   class Message < ApplicationRecord
 #     belongs_to :user
@@ -54,7 +54,7 @@
 #       end
 #   end
 #
-# If you want to render a renderable object you can use the `renderable:` option.
+# If you want to render a renderable object you can use the +renderable:+ option.
 #
 #   class Message < ApplicationRecord
 #     belongs_to :user
@@ -67,14 +67,68 @@
 #       end
 #   end
 #
-# There are four basic actions you can broadcast: <tt>remove</tt>, <tt>replace</tt>, <tt>append</tt>, and
-# <tt>prepend</tt>. As a rule, you should use the <tt>_later</tt> versions of everything except for remove when broadcasting
+# There are seven basic actions you can broadcast: <tt>after</tt>, <tt>append</tt>, <tt>before</tt>,
+# <tt>prepend</tt>, <tt>remove</tt>, <tt>replace</tt>, and
+# <tt>update</tt>. As a rule, you should use the <tt>_later</tt> versions of everything except for remove when broadcasting
 # within a real-time path, like a controller or model, since all those updates require a rendering step, which can slow down
 # execution. You don't need to do this for remove, since only the dom id for the model is used.
 #
-# In addition to the four basic actions, you can also use <tt>broadcast_render</tt>,
+# In addition to the seven basic actions, you can also use <tt>broadcast_render</tt>,
 # <tt>broadcast_render_to</tt> <tt>broadcast_render_later</tt>, and <tt>broadcast_render_later_to</tt>
 # to render a turbo stream template with multiple actions.
+#
+# == Page refreshes
+#
+# You can broadcast a "page refresh" to all clients subscribed to a stream. This is useful when you need to
+# broadcast a lot of partial updates, and the entire content is not easily updatable using Turbo stream actions like replace, append, prepend, or remove.
+#
+# It's recommended to use page refreshes as the primary option for broadcasting changes.
+# This approach allows you to remove the coupling between models and views to render complex partial updates without sacrificing the desired high UI fidelity.
+# We hope this makes using the other available Turbo Stream actions less necessary.
+#
+# The +broadcast_refreshes+ class method configures the model to broadcast a "page refresh" on creates, updates, and destroys to a stream
+# name derived at runtime by the <tt>stream</tt> symbol invocation. Examples
+#
+#   class Board < ApplicationRecord
+#     broadcast_refreshes
+#   end
+#
+# In this example, when a board is created, updated, or destroyed, a Turbo Stream for a
+# page refresh will be broadcasted to all clients subscribed to the "boards" stream.
+#
+# This works great in hierarchical structures, where the child record touches parent records automatically to invalidate the cache:
+#
+#   class Column < ApplicationRecord
+#     belongs_to :board, touch: true # +Board+ will trigger a page refresh on column changes
+#   end
+#
+# You can also specify the streamable declaratively by passing a symbol to the +broadcast_refreshes_to+ method:
+#
+#   class Column < ApplicationRecord
+#     belongs_to :board
+#     broadcast_refreshes_to :board
+#   end
+#
+# To achieve more granular control, , you can also broadcast a "page refresh" to a stream name derived from the passed <tt>streamables</tt> by using
+# the instance-level methods <tt>broadcast_refresh_to</tt> or <tt>broadcast_refresh_later_to</tt>.
+# These methods are particularly useful when you want to trigger a page refresh for more specific scenarios. Example:
+#
+#   class Clearance < ApplicationRecord
+#     belongs_to :petitioner, class_name: "Contact"
+#     belongs_to :examiner,   class_name: "User"
+#
+#     after_create_commit :broadcast_refresh_later
+#
+#     private
+#       def broadcast_refresh_later
+#         broadcast_refresh_later_to examiner.identity, :clearances
+#       end
+#   end
+#
+# In this example, a "page refresh" is broadcast to the stream named "identity:2:clearances" after a new clearance is created.
+# All clients subscribed to this stream will refresh the page to reflect the changes.
+#
+# When broadcasting page refreshes, Turbo will automatically debounce multiple calls in a row to only broadcast the last one. This is meant for scenarios where you process records in mass. Because of the nature of such signals, it makes no sense to broadcast them repeatedly and individually.
 #
 # == Suppressing broadcasts
 #
@@ -136,7 +190,17 @@ module Turbo::Broadcastable
     end
 
     # Configures the model to broadcast a "page refresh" on creates, updates, and destroys to a stream
-    # name derived at runtime by the <tt>stream</tt> symbol invocation.
+    # name derived at runtime by the <tt>stream</tt> symbol invocation. Examples:
+    #
+    #   class Message < ApplicationRecord
+    #     belongs_to :board
+    #     broadcasts_refreshes_to :board
+    #   end
+    #
+    #   class Message < ApplicationRecord
+    #     belongs_to :board
+    #     broadcasts_refreshes_to ->(message) { [ message.board, :messages ] }
+    #   end
     def broadcasts_refreshes_to(stream)
       after_commit -> { broadcast_refresh_later_to(stream.try(:call, self) || send(stream)) }
     end
@@ -293,10 +357,15 @@ module Turbo::Broadcastable
     broadcast_prepend_to self, target: target, **rendering
   end
 
+  #  Broadcast a "page refresh" to the stream name identified by the passed <tt>streamables</tt>. Example:
+  #
+  #   # Sends <turbo-stream action="refresh"></turbo-stream> to the stream named "identity:2:clearances"
+  #   clearance.broadcast_refresh_to examiner.identity, :clearances
   def broadcast_refresh_to(*streamables)
     Turbo::StreamsChannel.broadcast_refresh_to(*streamables) unless suppressed_turbo_broadcasts?
   end
 
+  #  Same as <tt>#broadcast_refresh_to</tt>, but the designated stream is automatically set to the current model.
   def broadcast_refresh
     broadcast_refresh_to self
   end
@@ -314,7 +383,6 @@ module Turbo::Broadcastable
   def broadcast_action(action, target: broadcast_target_default, attributes: {}, **rendering)
     broadcast_action_to self, action: action, target: target, attributes: attributes, **rendering
   end
-
 
   # Same as <tt>broadcast_replace_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_replace_later_to(*streamables, **rendering)
@@ -356,10 +424,12 @@ module Turbo::Broadcastable
     broadcast_prepend_later_to self, target: target, **rendering
   end
 
+  #  Same as <tt>broadcast_refresh_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_refresh_later_to(*streamables)
     Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id) unless suppressed_turbo_broadcasts?
   end
 
+  #  Same as <tt>#broadcast_refresh_later_to</tt>, but the designated stream is automatically set to the current model.
   def broadcast_refresh_later
     broadcast_refresh_later_to self
   end
@@ -390,7 +460,7 @@ module Turbo::Broadcastable
   #
   # Note that rendering inline via this method will cause template rendering to happen synchronously. That is usually not
   # desireable for model callbacks, certainly not if those callbacks are inside of a transaction. Most of the time you should
-  # be using `broadcast_render_later`, unless you specifically know why synchronous rendering is needed.
+  # be using +broadcast_render_later+, unless you specifically know why synchronous rendering is needed.
   def broadcast_render(**rendering)
     broadcast_render_to self, **rendering
   end
@@ -400,12 +470,12 @@ module Turbo::Broadcastable
   #
   # Note that rendering inline via this method will cause template rendering to happen synchronously. That is usually not
   # desireable for model callbacks, certainly not if those callbacks are inside of a transaction. Most of the time you should
-  # be using `broadcast_render_later_to`, unless you specifically know why synchronous rendering is needed.
+  # be using +broadcast_render_later_to+, unless you specifically know why synchronous rendering is needed.
   def broadcast_render_to(*streamables, **rendering)
     Turbo::StreamsChannel.broadcast_render_to(*streamables, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
   end
 
-  # Same as <tt>broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
+  # Same as <tt>broadcast_render_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
   def broadcast_render_later(**rendering)
     broadcast_render_later_to self, **rendering
   end
@@ -415,7 +485,6 @@ module Turbo::Broadcastable
   def broadcast_render_later_to(*streamables, **rendering)
     Turbo::StreamsChannel.broadcast_render_later_to(*streamables, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
   end
-
 
   private
     def broadcast_target_default

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -79,15 +79,16 @@
 #
 # == Page refreshes
 #
-# You can broadcast a "page refresh" to all clients subscribed to a stream. This is useful when you need to
-# broadcast a lot of partial updates, and the entire content is not easily updatable using Turbo stream actions like replace, append, prepend, or remove.
+# You can broadcast "page refresh" stream actions. This will make subscribed clients reload the 
+# page. For pages that configure morphing and scroll preservation, this will translate into smooth
+# updates when it only updates the content that changed.
+
+# This approach is an alternative to fine-grained stream actions targeting specific DOM elements. It
+# offers good fidelity with a much simpler programming model. As a tradeoff, the fidelity you can reach
+# is often not as high as with targeted stream actions since it renders the entire page again.
 #
-# It's recommended to use page refreshes as the primary option for broadcasting changes.
-# This approach allows you to remove the coupling between models and views to render complex partial updates without sacrificing the desired high UI fidelity.
-# We hope this makes using the other available Turbo Stream actions less necessary.
-#
-# The +broadcast_refreshes+ class method configures the model to broadcast a "page refresh" on creates, updates, and destroys to a stream
-# name derived at runtime by the <tt>stream</tt> symbol invocation. Examples
+# The +broadcast_refreshes+ class method configures the model to broadcast a "page refresh" on creates, 
+# updates, and destroys to a stream name derived at runtime by the <tt>stream</tt> symbol invocation. Examples
 #
 #   class Board < ApplicationRecord
 #     broadcast_refreshes
@@ -96,7 +97,8 @@
 # In this example, when a board is created, updated, or destroyed, a Turbo Stream for a
 # page refresh will be broadcasted to all clients subscribed to the "boards" stream.
 #
-# This works great in hierarchical structures, where the child record touches parent records automatically to invalidate the cache:
+# This works great in hierarchical structures, where the child record touches parent records automatically
+# to invalidate the cache:
 #
 #   class Column < ApplicationRecord
 #     belongs_to :board, touch: true # +Board+ will trigger a page refresh on column changes
@@ -109,9 +111,10 @@
 #     broadcast_refreshes_to :board
 #   end
 #
-# To achieve more granular control, , you can also broadcast a "page refresh" to a stream name derived from the passed <tt>streamables</tt> by using
-# the instance-level methods <tt>broadcast_refresh_to</tt> or <tt>broadcast_refresh_later_to</tt>.
-# These methods are particularly useful when you want to trigger a page refresh for more specific scenarios. Example:
+# For more granular control, you can also broadcast a "page refresh" to a stream name derived 
+# from the passed <tt>streamables</tt> by using the instance-level methods <tt>broadcast_refresh_to</tt> or
+# <tt>broadcast_refresh_later_to</tt>. These methods are particularly useful when you want to trigger 
+# a page refresh for more specific scenarios. Example:
 #
 #   class Clearance < ApplicationRecord
 #     belongs_to :petitioner, class_name: "Contact"
@@ -125,11 +128,13 @@
 #       end
 #   end
 #
-# In this example, a "page refresh" is broadcast to the stream named "identity:2:clearances" after a new clearance is created.
-# All clients subscribed to this stream will refresh the page to reflect the changes.
+# In this example, a "page refresh" is broadcast to the stream named "identity:<identity-id>:clearances" 
+# after a new clearance is created. All clients subscribed to this stream will refresh the page to reflect
+# the changes.
 #
-# When broadcasting page refreshes, Turbo will automatically debounce multiple calls in a row to only broadcast the last one. This is meant for scenarios where you process records in mass. Because of the nature of such signals, it makes no sense to broadcast them repeatedly and individually.
-#
+# When broadcasting page refreshes, Turbo will automatically debounce multiple calls in a row to only broadcast the last one. 
+# This is meant for scenarios where you process records in mass. Because of the nature of such signals, it makes no sense to
+# broadcast them repeatedly and individually.
 # == Suppressing broadcasts
 #
 # Sometimes, you need to disable broadcasts in certain scenarios. You can use <tt>.suppressing_turbo_broadcasts</tt> to create

--- a/lib/turbo/broadcastable/test_helper.rb
+++ b/lib/turbo/broadcastable/test_helper.rb
@@ -11,14 +11,14 @@ module Turbo
 
       # Asserts that `<turbo-stream>` elements were broadcast over Action Cable
       #
-      # === Arguments
+      # ==== Arguments
       #
       # * <tt>stream_name_or_object</tt> the objects used to generate the
       #   channel Action Cable name, or the name itself
       # * <tt>&block</tt> optional block executed before the
       #   assertion
       #
-      # === Options
+      # ==== Options
       #
       # * <tt>count:</tt> the number of `<turbo-stream>` elements that are
       # expected to be broadcast
@@ -70,7 +70,7 @@ module Turbo
 
       # Asserts that no `<turbo-stream>` elements were broadcast over Action Cable
       #
-      # === Arguments
+      # ==== Arguments
       #
       # * <tt>stream_name_or_object</tt> the objects used to generate the
       #   channel Action Cable name, or the name itself
@@ -113,7 +113,7 @@ module Turbo
 
       # Captures any `<turbo-stream>` elements that were broadcast over Action Cable
       #
-      # === Arguments
+      # ==== Arguments
       #
       # * <tt>stream_name_or_object</tt> the objects used to generate the
       #   channel Action Cable name, or the name itself

--- a/lib/turbo/test_assertions.rb
+++ b/lib/turbo/test_assertions.rb
@@ -10,7 +10,7 @@ module Turbo
     # Assert that the rendered fragment of HTML contains a `<turbo-stream>`
     # element.
     #
-    # === Options
+    # ==== Options
     #
     # * <tt>:action</tt> [String] matches the element's <tt>[action]</tt>
     #   attribute
@@ -55,7 +55,7 @@ module Turbo
     # Assert that the rendered fragment of HTML does not contain a `<turbo-stream>`
     # element.
     #
-    # === Options
+    # ==== Options
     #
     # * <tt>:action</tt> [String] matches the element's <tt>[action]</tt>
     #   attribute

--- a/lib/turbo/test_assertions/integration_test_assertions.rb
+++ b/lib/turbo/test_assertions/integration_test_assertions.rb
@@ -4,7 +4,7 @@ module Turbo
       # Assert that the Turbo Stream request's response body's HTML contains a
       # `<turbo-stream>` element.
       #
-      # === Options
+      # ==== Options
       #
       # * <tt>:status</tt> [Integer, Symbol] the HTTP response status
       # * <tt>:action</tt> [String] matches the element's <tt>[action]</tt>
@@ -47,7 +47,7 @@ module Turbo
       # Assert that the Turbo Stream request's response body's HTML does not
       # contain a `<turbo-stream>` element.
       #
-      # === Options
+      # ==== Options
       #
       # * <tt>:status</tt> [Integer, Symbol] the HTTP response status
       # * <tt>:action</tt> [String] matches the element's <tt>[action]</tt>


### PR DESCRIPTION
Currently, for newcomers, it is difficult to find the appropriate documentation to understand the value of turbo-rails and discover what it is capable of. If they reach RDoc, it is not intuitive to identify which classes and modules are responsible for the specific behavior of each part of turbo-rails oriented towards developers. We should make this information more visible to make it easier to get started.

This PR includes several typo corrections, suggestions from #516 and #524, documentation for some undocumented methods, and some explanations about page refreshes.

Additionally, in the README, the most important links to RDoc are included to make it easier to find and read the documentation. 

Please, I would love to receive feedback.