### PR TITLE
Remove deprecated Turbo::IncludesHelper

### DIFF
--- a/app/helpers/turbo/includes_helper.rb
+++ b/app/helpers/turbo/includes_helper.rb
@@ -1,7 +1,0 @@
-module Turbo::IncludesHelper
-  # DEPRECATED: Just use <tt>javascript_include_tag "turbo", type: "module"</tt> directly if using Turbo alone, or
-  # javascript_include_tag "turbo", type: "module-shim" if together with Stimulus and importmaps.
-  def turbo_include_tags
-    javascript_include_tag("turbo", type: "module")
-  end
-end


### PR DESCRIPTION
Since we are updating to the next major version, we could remove the `Turbo::IncludesHelper` deprecated helper.