### PR TITLE
Render full documents for requests with `Turbo-Frame:` header

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -21,7 +21,6 @@ module Turbo::Frames::FrameRequest
   extend ActiveSupport::Concern
 
   included do
-    layout -> { "turbo_rails/frame" if turbo_frame_request? }
     etag { :frame if turbo_frame_request? }
 
     helper_method :turbo_frame_request?, :turbo_frame_request_id

--- a/app/views/layouts/turbo_rails/frame.html.erb
+++ b/app/views/layouts/turbo_rails/frame.html.erb
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <%= yield :head %>
-  </head>
-  <body>
-    <%= yield %>
-  </body>
-</html>

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -6,7 +6,7 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     assert_select "title", count: 1
 
     get tray_path(id: 1), headers: { "Turbo-Frame" => "true" }
-    assert_select "title", count: 0
+    assert_select "title", count: 1
   end
 
   test "frame request layout includes `head` content" do
@@ -22,7 +22,7 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_select "meta[name=test][content=present]"
-    assert_select "meta[name=alternative][content=present]"
+    assert_select "meta[name=alternative][content=present]", count: 0
   end
 
   test "frame requests get a unique etag" do


### PR DESCRIPTION
Re-submission of [#232][]
Related to [hotwired/turbo#1047][]

Render full documents, including default layout rendering behavior.

Rendering a minimal layout forces `turbo:reload` events because of the severe difference in the contents of the minimal layout's `<head>` and the requesting document's fully populated `<head>`.

[#232]: https://github.com/hotwired/turbo-rails/pull/232
[hotwired/turbo#1047]: https://github.com/hotwired/turbo/issues/1047