### PR TITLE
Separate turbo meta tag generation from provides

### DIFF
--- a/app/helpers/turbo/drive_helper.rb
+++ b/app/helpers/turbo/drive_helper.rb
@@ -1,10 +1,10 @@
 module Turbo::DriveHelper
-  # Note: These helpers require a +yield :head+ provision in the layout.
+  # Note: These helpers require a +turbo_meta_tags+ provision in the layout.
   #
   # ==== Example
   #
   #   # app/views/application.html.erb
-  #   <html><head><%= yield :head %></head><body><%= yield %></html>
+  #   <html><head><%= turbo_meta_tags %></head><body><%= yield %></html>
   #
   #   # app/views/trays/index.html.erb
   #   <% turbo_exempts_page_from_cache %>
@@ -13,25 +13,49 @@ module Turbo::DriveHelper
   # Pages that are more likely than not to be a cache miss can skip turbo cache to avoid visual jitter.
   # Cannot be used along with +turbo_exempts_page_from_preview+.
   def turbo_exempts_page_from_cache
-    provide :head, tag.meta(name: "turbo-cache-control", content: "no-cache")
+    provide :head, turbo_exempts_page_from_cache_tag
+  end
+
+  def turbo_exempts_page_from_cache_tag
+    tag.meta(name: "turbo-cache-control", content: "no-cache")
   end
 
   # Specify that a cached version of the page should not be shown as a preview during an application visit.
   # Cannot be used along with +turbo_exempts_page_from_cache+.
   def turbo_exempts_page_from_preview
-    provide :head, tag.meta(name: "turbo-cache-control", content: "no-preview")
+    provide :head, turbo_exempts_page_from_preview_tag
+  end
+
+  def turbo_exempts_page_from_preview_tag
+    tag.meta(name: "turbo-cache-control", content: "no-preview")
   end
 
   # Force the page, when loaded by Turbo, to be cause a full page reload.
   def turbo_page_requires_reload
-    provide :head, tag.meta(name: "turbo-visit-control", content: "reload")
+    provide :head, turbo_page_requires_reload_tag
+  end
+
+  def turbo_page_requires_reload_tag
+    tag.meta(name: "turbo-visit-control", content: "reload")
   end
 
   def turbo_refreshes_with(method: :replace, scroll: :reset)
-    raise ArgumentError, "Invalid refresh option '#{method}'" unless method.in?(%i[ replace morph ])
-    raise ArgumentError, "Invalid scroll option '#{scroll}'" unless scroll.in?(%i[ reset preserve ])
+    provide :head, turbo_refresh_method_tag(method)
+    provide :head, turbo_refresh_scroll_tag(scroll)
+  end
 
-    provide :head, tag.meta(name: "turbo-refresh-method", content: method)
-    provide :head, tag.meta(name: "turbo-refresh-scroll", content: scroll)
+  def turbo_refresh_method_tag(method = :replace)
+    raise ArgumentError, "Invalid refresh option '#{method}'" unless method.in?(%i[ replace morph ])
+    tag.meta(name: "turbo-refresh-method", content: method)
+  end
+
+  def turbo_refresh_scroll_tag(scroll = :reset)
+    raise ArgumentError, "Invalid scroll option '#{scroll}'" unless scroll.in?(%i[ reset preserve ])
+    tag.meta(name: "turbo-refresh-scroll", content: scroll)
+  end
+
+  def turbo_meta_tags
+    content_for :head
   end
 end
+

--- a/app/views/layouts/turbo_rails/frame.html.erb
+++ b/app/views/layouts/turbo_rails/frame.html.erb
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <%= yield :head %>
+    <%= turbo_meta_tags %>
   </head>
   <body>
     <%= yield %>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= yield :head %>
+    <%= turbo_meta_tags %>
     <%= javascript_importmap_tags %>
   </head>
 

--- a/test/frames/views/layouts/turbo_rails/frame.html.erb
+++ b/test/frames/views/layouts/turbo_rails/frame.html.erb
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="alternative" content="present" />
-    <%= yield :head %>
+    <%= turbo_meta_tags %>
   </head>
   <body>
     <%= yield %>


### PR DESCRIPTION
Removes the requirement to have a `content_for :head` tag in the head of the Rails application. Instead the developer just adds the `turbo_meta_tags(method: :morph, scroll: :preserve)` to the top of their pages and it will setup the `yield :turbo_head` block that the helpers provide via `provide :turbo_head`.

That means developers can do this:

```
<head>
  <%= turbo_meta_tags method: :morph, scroll: :preserve %>
</head>
```

Instead of this:

```
<head>
  <%= turbo_refreshes_with method: :morph, scroll: :preserve  %>
  <%= content_for :head %>
</head>
```

And prevent confusion like this: https://www.reddit.com/r/rails/comments/186z9lu/comment/kd60oq4/?utm_source=reddit&utm_medium=web2x&context=3

This also makes it possible to use the meta tag helpers from outside Rails rendering, such as an app built entirely from Phlex components.

If there's general interest in merging PRs that improve the developer experience, I could make additional improvements that make configuring Turbo pages easier from the controller in addition to the view.