### PR TITLE
Remove Ruby 2.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         rails: [ "6.1", "7.0", "7.1" ]
-        ruby: [ "2.7", "3.0", "3.1", "3.2" ]
+        ruby: [ "3.0", "3.1", "3.2", "3.3" ]
         allow-fail: [ false ]
         include:
-          - { ruby: "2.7",  rails: "main", allow-fail: true }
+          - { ruby: "3.3",  rails: "main", allow-fail: true }
           - { ruby: "3.2",  rails: "main", allow-fail: true }
           - { ruby: "head", rails: "main", allow-fail: true }
 


### PR DESCRIPTION
It was EOLed on 2023-03-31. Test Ruby 3.3 instead.