### PR TITLE
Update Turbo Drive `<meta>` across navigations

### DIFF
--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -1,0 +1,2 @@
+class PagesController < ApplicationController
+end

--- a/test/dummy/app/views/pages/show.html.erb
+++ b/test/dummy/app/views/pages/show.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_refreshes_with method: params.fetch(:turbo_refresh_method, :replace).to_sym, scroll: params.fetch(:turbo_refresh_scroll, :reset).to_sym %>
+
+<h1><%= params[:id].titleize %></h1>
+
+<% {
+  classic: {
+    turbo_refresh_method: :replace,
+    turbo_refresh_scroll: :reset,
+  },
+  morph: {
+    turbo_refresh_method: :morph,
+    turbo_refresh_scroll: :preserve,
+  }
+}.each do |id, refresh| %>
+  <%= link_to_unless_current id.to_s.titleize, page_path(id, refresh) %>
+<% end %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :pages, only: :show
   resources :articles do
     delete :destroy_all, on: :collection
   end

--- a/test/system/navigations_test.rb
+++ b/test/system/navigations_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class NavigationsTest < ApplicationSystemTestCase
+  test "navigation updates Turbo Refresh meta tags" do
+    visit page_path(:classic)
+
+    within "head", visible: false do
+      assert_selector :element, "meta", name: "turbo-refresh-method", content: "replace", visible: false, count: 1
+      assert_selector :element, "meta", name: "turbo-refresh-scroll", content: "reset", visible: false, count: 1
+    end
+
+    click_link "Morph"
+
+    within "head", visible: false do
+      assert_selector :element, "meta", name: "turbo-refresh-method", content: "morph", visible: false, count: 1
+      assert_selector :element, "meta", name: "turbo-refresh-scroll", content: "preserve", visible: false, count: 1
+    end
+
+    click_link "Classic"
+
+    within "head", visible: false do
+      assert_selector :element, "meta", name: "turbo-refresh-method", content: "replace", visible: false, count: 1
+      assert_selector :element, "meta", name: "turbo-refresh-scroll", content: "reset", visible: false, count: 1
+    end
+  end
+end


### PR DESCRIPTION
Closes [#549]

Add System Test level coverage to ensure that Turbo Drive navigations will re-render any `<meta>` elements nested within the document's `<head>`.

To achieve this coverage, introduce the `PagesController#show` action that links to HTML pages that render their `<head>` based on the `turbo_refresh_method` and `turbo_refresh_scroll` query parameters.

[#549]: https://github.com/hotwired/turbo-rails/issues/549