### PR TITLE
Raise exception when no id is passed to the turbo_frame_tag helper

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -38,7 +38,12 @@ module Turbo::FramesHelper
   #
   #   <%= turbo_frame_tag(Article.find(1), Comment.new) %>
   #   # => <turbo-frame id="article_1_new_comment"></turbo-frame>
+  #
+  # Raises an +ArgumentError+ if called without a frame id.
+  #   <%= turbo_frame_tag(nil) %> # => ArgumentError: You must supply a frame id
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
+    raise ArgumentError, "You must supply a frame id" if ids.all? { |id| id.blank? }
+
     id = ids.first.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.join('_')
     src = url_for(src) if src.present?
 

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -21,6 +21,26 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
   end
 
+  test "frame with invalid argument should raise ArgumentError" do
+    assert_raises ArgumentError, "ArgumentError: You must supply a frame id" do
+      record = nil
+
+      turbo_frame_tag(record)
+    end
+
+    assert_raises ArgumentError, "ArgumentError: You must supply a frame id" do
+      record = []
+
+      turbo_frame_tag(record)
+    end
+
+    assert_raises ArgumentError, "ArgumentError: You must supply a frame id" do
+      record = ''
+
+      turbo_frame_tag(record)
+    end
+  end
+
   test "string frame within a model frame" do
     record = Article.new(id: 1)
 


### PR DESCRIPTION
Hi Folks,

This PR was created after I went through a debug session to see why one of my Turbo frames was not working correctly. I've misspelled one of the instance variables, and Turbo created a frame with an empty id. 

After thinking for a little bit, I couldn't think of a use case where it's expected/intended to create a turbo frame with an empty tag, so I created a pull request that raises `ArgumentError` if a valid ID is not passed. (please correct me If there's any use case where we expect to create a turbo frame with empty IDs). 

Thiago

