### PR TITLE
Fix double registration of :turbo_stream Renderer

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -63,11 +63,9 @@ module Turbo
     end
 
     initializer "turbo.renderer" do
-      ActiveSupport.on_load(:action_controller) do
-        ActionController::Renderers.add :turbo_stream do |turbo_streams_html, options|
-          self.content_type = Mime[:turbo_stream] if media_type.nil?
-          turbo_streams_html
-        end
+      ActionController::Renderers.add :turbo_stream do |turbo_streams_html, options|
+        self.content_type = Mime[:turbo_stream] if media_type.nil?
+        turbo_streams_html
       end
     end
 

--- a/test/dummy/app/controllers/api/application_controller.rb
+++ b/test/dummy/app/controllers/api/application_controller.rb
@@ -1,0 +1,2 @@
+class Api::ApplicationController < ActionController::API
+end

--- a/test/dummy/app/mailboxes/application_mailbox.rb
+++ b/test/dummy/app/mailboxes/application_mailbox.rb
@@ -1,2 +1,0 @@
-class ApplicationMailbox < ActionMailbox::Base
-end

--- a/test/dummy/app/mailboxes/messages_mailbox.rb
+++ b/test/dummy/app/mailboxes/messages_mailbox.rb
@@ -1,4 +1,0 @@
-class MessagesMailbox < ApplicationMailbox
-  def process
-  end
-end

--- a/test/dummy/app/mailers/application_mailer.rb
+++ b/test/dummy/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
When an application loads both `ActionController::Base` and
`ActionController::API`, the `:action_controller` load hook gets called
twice (once for each of them). Since the `:turbo_stream` Renderer is
registered in this load hook, it ends up getting registered twice and
prints a warning for method redefinition.

To demonstrate the warning in the `turbo-rails` tests, an
`Api::ApplicationController` was added to the dummy app so that both
base controller classes get loaded:

```
$ CI=true bundle exec rake test
/home/hartley/.cache/asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/actionpack-7.1.3/lib/action_controller/metal/renderers.rb:75: warning: method redefined; discarding old _render_with_renderer_turbo_stream
/home/hartley/src/github.com/skipkayhil/turbo-rails/lib/turbo/engine.rb:67: warning: previous definition of _render_with_renderer_turbo_stream was here
```

This commit fixes the issue by not using the `:action_controller` load
hook to register the `:turbo_stream` Renderer. Adding a Renderer should
not require a lazy load hook because `ActionController::Renderers` does
not load any other classes.