### PR TITLE
Make `turbo_frame_request?` a helper method

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -24,7 +24,7 @@ module Turbo::Frames::FrameRequest
     layout -> { "turbo_rails/frame" if turbo_frame_request? }
     etag { :frame if turbo_frame_request? }
 
-    helper_method :turbo_frame_request_id
+    helper_method :turbo_frame_request?, :turbo_frame_request_id
   end
 
   private


### PR DESCRIPTION
In my app, I was making an index view of records with an info frame at the top where you could edit the parent record. I thought that with broadcasting page refreshes everything would be updated even though in the controller it redirects to the same page (therefore normally only updating the frame), but because of the debouncing mechanism it didn't. I fixed the problem by forcing a full page reload if it came from a frame request, however, since only the `turbo_frame_request_id` method is defined as a helper, I can't just use `turbo_frame_request?` and have to use the more awkward `turbo_frame_request_id.present?`.