### PR TITLE
Include broadcastable assertions automatically in ActiveSupport::TestCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The [`Turbo::TestAssertions`](./lib/turbo/test_assertions.rb) concern provides T
 
 The [`Turbo::TestAssertions::IntegrationTestAssertions`](./lib/turbo/test_assertions/integration_test_assertions.rb) are built on top of `Turbo::TestAssertions`, and add support for passing a `status:` keyword. They are automatically included in [`ActionDispatch::IntegrationTest`](https://edgeguides.rubyonrails.org/testing.html#integration-testing).
 
-The [`Turbo::Broadcastable::TestHelper`](./lib/turbo/broadcastable/test_helper.rb) concern provides Action Cable-aware test helpers that assert that `<turbo-stream>` elements were or were not broadcast over Action Cable. They are not automatically included. To use them in your tests, make sure to `include Turbo::Broadcastable::TestHelper`.
+The [`Turbo::Broadcastable::TestHelper`](./lib/turbo/broadcastable/test_helper.rb) concern provides Action Cable-aware test helpers that assert that `<turbo-stream>` elements were or were not broadcast over Action Cable. `Turbo::Broadcastable::TestHelper` is automatically included in [`ActiveSupport::TestCase`](https://edgeapi.rubyonrails.org/classes/ActiveSupport/TestCase.html).
 
 ## Development
 

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -84,6 +84,7 @@ module Turbo
         require "turbo/broadcastable/test_helper"
 
         include Turbo::TestAssertions
+        include Turbo::Broadcastable::TestHelper
       end
 
       ActiveSupport.on_load(:action_dispatch_integration_test) do


### PR DESCRIPTION
There is a note in the Campfire codebase `test_helper`:

![image](https://github.com/hotwired/turbo-rails/assets/56947/f9b647eb-e50e-463e-a36e-8b28bc4ffd3e)

And I noticed I had the same patch in my own codebase:

![image](https://github.com/hotwired/turbo-rails/assets/56947/81846a66-f8e6-4c85-b72a-10aa14ff0080)

In https://github.com/hotwired/turbo-rails/pull/466 it explicitly mentioned the `Broadcastable::TestHelpers` are "not automatically included" -- but I'm not sure why. @seanpdoyle any insights?