### PR TITLE
Use content_tag instead of tag helper

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -42,6 +42,6 @@ module Turbo::FramesHelper
     id = ids.first.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.join('_')
     src = url_for(src) if src.present?
 
-    tag_builder.tag_string(:turbo_frame, **attributes.merge(id: id, src: src, target: target).compact, &block)
+    content_tag(:turbo_frame, nil, **attributes.merge(id: id, src: src, target: target).compact, &block)
   end
 end


### PR DESCRIPTION
This PR enhances performance by replacing the usage of `tag` with `tag_builder.tag_string`. 
This change eliminates the overhead of going through method_missing, resulting in faster HTML generation.