### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This gem is automatically configured for applications made with Rails 7+ (unless
 3. Run `./bin/rails turbo:install`
 4. Run `./bin/rails turbo:install:redis` to change the development Action Cable adapter from Async (the default one) to Redis. The Async adapter does not support Turbo Stream broadcasting.
 
-Running `turbo:install` will install through NPM if Node.js is used in the application. Otherwise the asset pipeline version is used. To use the asset pipeline version, you must have `importmap-rails` installed first and listed higher in the Gemfile.
+Running `turbo:install` will install through NPM or Bun if a JavaScript runtime is used in the application. Otherwise the asset pipeline version is used. To use the asset pipeline version, you must have `importmap-rails` installed first and listed higher in the Gemfile.
 
 If you're using node and need to use the cable consumer, you can import [`cable`](https://github.com/hotwired/turbo-rails/blob/main/app/javascript/turbo/cable.js) (`import { cable } from "@hotwired/turbo-rails"`), but ensure that your application actually *uses* the members it `import`s when using this style (see [turbo-rails#48](https://github.com/hotwired/turbo-rails/issues/48)).
 

--- a/app/channels/turbo/streams_channel.rb
+++ b/app/channels/turbo/streams_channel.rb
@@ -9,27 +9,27 @@
 # helper modules like <tt>Turbo::Streams::StreamName</tt>:
 #
 #   class CustomChannel < ActionCable::Channel::Base
-#      extend Turbo::Streams::Broadcasts, Turbo::Streams::StreamName
-#      include Turbo::Streams::StreamName::ClassMethods
+#     extend Turbo::Streams::Broadcasts, Turbo::Streams::StreamName
+#     include Turbo::Streams::StreamName::ClassMethods
 #
-#      def subscribed
-#        if (stream_name = verified_stream_name_from_params).present? &&
+#     def subscribed
+#       if (stream_name = verified_stream_name_from_params).present? &&
 #           subscription_allowed?
-#          stream_from stream_name
-#        else
-#          reject
-#        end
-#      end
+#         stream_from stream_name
+#       else
+#         reject
+#       end
+#     end
 #
-#      def subscription_allowed?
-#         # ...
-#      end
+#     def subscription_allowed?
+#       # ...
+#     end
 #   end
 #
-#  This channel can be connected to a web page using <tt>:channel</tt> option in
-#  <tt>turbo_stream_from</tt> helper:
+# This channel can be connected to a web page using <tt>:channel</tt> option in
+# <tt>turbo_stream_from</tt> helper:
 #
-#    <%= turbo_stream_from 'room', channel: CustomChannel %>
+#   <%= turbo_stream_from 'room', channel: CustomChannel %>
 #
 class Turbo::StreamsChannel < ActionCable::Channel::Base
   extend Turbo::Streams::Broadcasts, Turbo::Streams::StreamName

--- a/app/helpers/turbo/drive_helper.rb
+++ b/app/helpers/turbo/drive_helper.rb
@@ -51,7 +51,7 @@ module Turbo::DriveHelper
   # Configure how to handle page refreshes. A page refresh happens when
   # Turbo loads the current page again with a *replace* visit:
   #
-  # === Parameters:
+  # ==== Parameters:
   #
   # * <tt>method</tt> - Method to update the +<body>+ of the page
   #   during a page refresh. It can be one of:
@@ -64,7 +64,7 @@ module Turbo::DriveHelper
   #   * +reset:+: Resets scroll to the top, left corner. This is the default.
   #   * +preserve:+: Keeps the scroll.
   #
-  # === Example Usage:
+  # ==== Example Usage:
   #
   #   turbo_refreshes_with(method: :morph, scroll: :preserve)
   def turbo_refreshes_with(method: :replace, scroll: :reset)

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -82,7 +82,7 @@
 # You can broadcast "page refresh" stream actions. This will make subscribed clients reload the 
 # page. For pages that configure morphing and scroll preservation, this will translate into smooth
 # updates when it only updates the content that changed.
-
+#
 # This approach is an alternative to fine-grained stream actions targeting specific DOM elements. It
 # offers good fidelity with a much simpler programming model. As a tradeoff, the fidelity you can reach
 # is often not as high as with targeted stream actions since it renders the entire page again.


### PR DESCRIPTION
In #530 several improvements were made to the documentation but there were a few small typos that caused some things to not display well, and others not to display at all. This PR fixes that.

cc @jorgemanrubia