### PR TITLE
Add turbo_disable_prefetch helper

### DIFF
--- a/app/helpers/turbo/drive_helper.rb
+++ b/app/helpers/turbo/drive_helper.rb
@@ -83,5 +83,15 @@ module Turbo::DriveHelper
     raise ArgumentError, "Invalid scroll option '#{scroll}'" unless scroll.in?(%i[ reset preserve ])
     tag.meta(name: "turbo-refresh-scroll", content: scroll)
   end
+
+     # Disable InstantClick (prefetch).
+  def turbo_disable_prefetch
+    provide :head, turbo_disable_prefetch_tag
+  end
+
+  # See +turbo_disable_prefetch+.
+  def turbo_disable_prefetch_tag
+    tag.meta(name: "turbo-prefetch", content: "false")
+  end
 end
 

--- a/test/drive/drive_helper_test.rb
+++ b/test/drive/drive_helper_test.rb
@@ -16,6 +16,11 @@ class Turbo::DriveHelperTest < ActionDispatch::IntegrationTest
     assert_match(/<meta name="turbo-refresh-method" content="morph">/, @response.body)
     assert_match(/<meta name="turbo-refresh-scroll" content="preserve">/, @response.body)
   end
+
+  test "opting out of the default prefetch" do
+    get trays_path
+    assert_match(/<meta name="turbo-prefetch" content="false">/, @response.body)
+  end
 end
 
 class Turbo::DriverHelperUnitTest < ActionView::TestCase

--- a/test/dummy/app/views/trays/index.html.erb
+++ b/test/dummy/app/views/trays/index.html.erb
@@ -1,5 +1,6 @@
 <% turbo_exempts_page_from_cache %>
 <% turbo_page_requires_reload %>
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+<%= turbo_disable_prefetch %>
 
 <p>Not in the cache!</p>


### PR DESCRIPTION
I needed to disable the `InstantClick` prefetch behavior as specified in the documentation [InstantClick](https://turbo.hotwired.dev/handbook/drive#instantclick) on a number of pages for an existing application.

I've added two helpers `turbo_disable_prefetch` and `turbo_disable_prefetch_tag` to make it more convenient.


PS : 
It's my real first PR, so if I miss something, please let me know.