### PR TITLE
Only include `Turbo::Broadcastable::TestHelper`  with Action Cable

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -81,10 +81,14 @@ module Turbo
     initializer "turbo.test_assertions" do
       ActiveSupport.on_load(:active_support_test_case) do
         require "turbo/test_assertions"
-        require "turbo/broadcastable/test_helper"
-
         include Turbo::TestAssertions
-        include Turbo::Broadcastable::TestHelper
+      end
+
+      ActiveSupport.on_load(:action_cable) do
+        ActiveSupport.on_load(:active_support_test_case) do
+          require "turbo/broadcastable/test_helper"
+          include Turbo::Broadcastable::TestHelper
+        end
       end
 
       ActiveSupport.on_load(:action_dispatch_integration_test) do


### PR DESCRIPTION
Closes [#573][]
Related to [#565][]

Re-structure the automatic inclusion of the
`Turbo::Broadcastable::TestHelper` module so that it's only automatically loaded and installed when Action Cable is available to the runtime.

[#573]: https://github.com/hotwired/turbo-rails/issues/573
[#565]: https://github.com/hotwired/turbo-rails/pull/565#issuecomment-1935720027