### PR TITLE
Add `turbo_stream.refresh` builder method

### DIFF
--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -228,6 +228,18 @@ class Turbo::Streams::TagBuilder
     action_all :prepend, targets, content, **rendering, &block
   end
 
+  # Creates a `turbo-stream` tag with an `[action="refresh"`] attribute and a
+  # `[request-id]` attribute that defaults to `Turbo.current_request_id`:
+  #
+  #   turbo_stream.refresh
+  #   # => <turbo-stream action="refresh" request-id="ef083d55-7516-41b1-ad28-16f553399c6a"></turbo-stream>
+  #
+  #   turbo_stream.refresh request_id: "abc123"
+  #   # => <turbo-stream action="refresh" request-id="abc123"></turbo-stream>
+  def refresh(...)
+    turbo_stream_refresh_tag(...)
+  end
+
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.
   def action(name, target, content = nil, allow_inferred_rendering: true, **rendering, &block)
     template = render_template(target, content, allow_inferred_rendering: allow_inferred_rendering, **rendering, &block)

--- a/test/streams/streams_helper_test.rb
+++ b/test/streams/streams_helper_test.rb
@@ -35,6 +35,18 @@ class Turbo::StreamsHelperTest < ActionView::TestCase
       turbo_stream_from("messages", channel: "NonExistentChannel", data: {payload: 1})
   end
 
+  test "turbo_stream.refresh" do
+    assert_dom_equal <<~HTML, turbo_stream.refresh
+      <turbo-stream action="refresh"></turbo-stream>
+    HTML
+    assert_dom_equal <<~HTML, Turbo.with_request_id("abc123") { turbo_stream.refresh }
+      <turbo-stream request-id="abc123" action="refresh"></turbo-stream>
+    HTML
+    assert_dom_equal <<~HTML, turbo_stream.refresh(request_id: "def456")
+      <turbo-stream request-id="def456" action="refresh"></turbo-stream>
+    HTML
+  end
+
   test "custom turbo_stream builder actions" do
     assert_dom_equal <<~HTML.strip, turbo_stream.highlight("an-id")
       <turbo-stream action="highlight" target="an-id"><template></template></turbo-stream>


### PR DESCRIPTION
Closes [#579][]

Extends the `turbo_stream` tag builder helper to create `<turbo-stream action="refresh">` elements through the pre-existing `turbo_stream_refresh_tag` method.

[#579]: https://github.com/hotwired/turbo-rails/issues/579