### PR TITLE
Add support for Model Class in Action and Frame helpers

### DIFF
--- a/app/helpers/turbo/frames_helper.rb
+++ b/app/helpers/turbo/frames_helper.rb
@@ -33,10 +33,13 @@ module Turbo::FramesHelper
   #   <%= turbo_frame_tag(Article.find(1)) %>
   #   # => <turbo-frame id="article_1"></turbo-frame>
   #
+  #   <%= turbo_frame_tag(Article) %>
+  #   # => <turbo-frame id="new_article"></turbo-frame>
+  #
   #   <%= turbo_frame_tag(Article.find(1), "comments") %>
   #   # => <turbo-frame id="comments_article_1"></turbo-frame>
   def turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)
-    id = ids.first.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.join('_')
+    id = ids.first.respond_to?(:to_key) || ids.first.is_a?(Class) ? ActionView::RecordIdentifier.dom_id(*ids) : ids.join('_')
     src = url_for(src) if src.present?
 
     tag.turbo_frame(**attributes.merge(id: id, src: src, target: target).compact, &block)

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -19,6 +19,9 @@ module Turbo::Streams::ActionHelper
   #   turbo_stream_action_tag "remove", target: message
   #   # => <turbo-stream action="remove" target="message_1"></turbo-stream>
   #
+  #   turbo_stream_action_tag "remove", target: Message
+  #   # => <turbo-stream action="remove" target="new_message"></turbo-stream>
+  #
   #   message = Message.find(1)
   #   turbo_stream_action_tag "remove", target: [message, :special]
   #   # => <turbo-stream action="remove" target="special_message_1"></turbo-stream>
@@ -44,7 +47,7 @@ module Turbo::Streams::ActionHelper
 
   private
     def convert_to_turbo_stream_dom_id(target, include_selector: false)
-      if Array(target).any? { |value| value.respond_to?(:to_key) }
+      if Array(target).any? { |value| value.respond_to?(:to_key) || value.is_a?(Class) }
         "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(*target)}"
       else
         target

--- a/test/frames/frames_helper_test.rb
+++ b/test/frames/frames_helper_test.rb
@@ -21,6 +21,10 @@ class Turbo::FramesHelperTest < ActionView::TestCase
     assert_dom_equal %(<turbo-frame id="message_1"></turbo-frame>), turbo_frame_tag(record)
   end
 
+  test "frame with model class argument" do
+    assert_dom_equal %(<turbo-frame id="new_message"></turbo-frame>), turbo_frame_tag(Message)
+  end
+
   test "string frame within a model frame" do
     record = Article.new(id: 1)
 

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -11,6 +11,14 @@ class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
     assert_equal stream, turbo_stream_action_tag("append", target: message)
   end
 
+  test "target is a model class" do
+    message = Message
+
+    stream = "<turbo-stream action=\"append\" target=\"new_message\"><template></template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: message)
+  end
+
   test "target passed as array of dom_id arguments" do
     message = Message.new(id: 1)
 


### PR DESCRIPTION
Hello,

This PR updates the `turbo_frame_tag` and `turbo_stream_action_tag` helpers to support passing a class argument in the same way `ActionView::RecordIdentifier#dom_id` does.

I updated the methods to also check for a `Class` since `dom_id` essentially does that.

I didn't see any contributor docs so I'm not sure if I missed something.
Thanks.