### PR TITLE
Do not load ActiveJobs if ActiveJob is not loaded

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -1,4 +1,4 @@
-# Turbo streams can be broadcasted directly from models that include this module (this is automatically done for Active Records).
+# Turbo streams can be broadcasted directly from models that include this module (this is automatically done for Active Records if ActiveJob is loaded).
 # This makes it convenient to execute both synchronous and asynchronous updates, and render directly from callbacks in models
 # or from controllers or jobs that act on those models. Here's an example:
 #

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -91,8 +91,10 @@ module Turbo
     end
 
     initializer "turbo.broadcastable" do
-      ActiveSupport.on_load(:active_record) do
-        include Turbo::Broadcastable
+      ActiveSupport.on_load(:active_job) do
+        ActiveSupport.on_load(:active_record) do
+          include Turbo::Broadcastable
+        end
       end
     end
 
@@ -120,10 +122,12 @@ module Turbo
         include Turbo::TestAssertions
       end
 
-      ActiveSupport.on_load(:action_cable) do
-        ActiveSupport.on_load(:active_support_test_case) do
-          require "turbo/broadcastable/test_helper"
-          include Turbo::Broadcastable::TestHelper
+      ActiveSupport.on_load(:active_job) do
+        ActiveSupport.on_load(:action_cable) do
+          ActiveSupport.on_load(:active_support_test_case) do
+            require "turbo/broadcastable/test_helper"
+            include Turbo::Broadcastable::TestHelper
+          end
         end
       end
 

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -15,6 +15,27 @@ module Turbo
       #{root}/app/jobs
     )
 
+    # If the parent application does not use Active Job, app/jobs cannot
+    # be eager loaded, because it references the ActiveJob constant.
+    #
+    # When turbo-rails depends on Rails 7 or above, the entire block can be
+    # reduced to
+    #
+    #   unless defined?(ActiveJob)
+    #     Rails.autoloaders.once.do_not_eager_load("#{root}/app/jobs")
+    #   end
+    #
+    initializer "turbo.no_active_job", before: :set_eager_load_paths do
+      unless defined?(ActiveJob)
+        if Rails.autoloaders.zeitwerk_enabled?
+          Rails.autoloaders.once.do_not_eager_load("#{root}/app/jobs")
+        else
+          # This else branch only runs in Rails 6.x + classic mode.
+          config.eager_load_paths.delete("#{root}/app/jobs")
+        end
+      end
+    end
+
     # If the parent application does not use Action Cable, app/channels cannot
     # be eager loaded, because it references the ActionCable constant.
     #

--- a/test/broadcastable/test_helper_test.rb
+++ b/test/broadcastable/test_helper_test.rb
@@ -1,263 +1,269 @@
 require "test_helper"
 
-class Turbo::Broadcastable::TestHelper::CaptureTurboStreamBroadcastsTest < ActiveSupport::TestCase
-  include Turbo::Broadcastable::TestHelper
+module Turbo
+  module Broadcastable
+    module TestHelper
+      class CaptureTurboStreamBroadcastsTest < ActiveSupport::TestCase
+        include Turbo::Broadcastable::TestHelper
 
-  test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream name" do
-    message = Message.new(id: 1)
+        test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream name" do
+          message = Message.new(id: 1)
 
-    message.broadcast_replace_to "messages"
-    message.broadcast_remove_to "messages"
-    replace, remove, *rest = capture_turbo_stream_broadcasts "messages"
+          message.broadcast_replace_to "messages"
+          message.broadcast_remove_to "messages"
+          replace, remove, *rest = capture_turbo_stream_broadcasts "messages"
 
-    assert_empty rest
-    assert_equal "replace", replace["action"]
-    assert_equal "remove", remove["action"]
-    assert_not_empty replace.at("template").element_children
-    assert_nil remove.at("template")
-  end
+          assert_empty rest
+          assert_equal "replace", replace["action"]
+          assert_equal "remove", remove["action"]
+          assert_not_empty replace.at("template").element_children
+          assert_nil remove.at("template")
+        end
 
-  test "#capture_turbo_stream_broadcasts returns an empty Array when no broadcasts happened on a stream name" do
-    assert_empty capture_turbo_stream_broadcasts("messages")
-  end
+        test "#capture_turbo_stream_broadcasts returns an empty Array when no broadcasts happened on a stream name" do
+          assert_empty capture_turbo_stream_broadcasts("messages")
+        end
 
-  test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream object" do
-    message = Message.new(id: 1)
+        test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream object" do
+          message = Message.new(id: 1)
 
-    message.broadcast_replace
-    message.broadcast_remove
-    replace, remove, *rest = capture_turbo_stream_broadcasts message
+          message.broadcast_replace
+          message.broadcast_remove
+          replace, remove, *rest = capture_turbo_stream_broadcasts message
 
-    assert_empty rest
-    assert_equal "replace", replace["action"]
-    assert_equal "remove", remove["action"]
-    assert_not_empty replace.at("template").element_children
-    assert_nil remove.at("template")
-  end
+          assert_empty rest
+          assert_equal "replace", replace["action"]
+          assert_equal "remove", remove["action"]
+          assert_not_empty replace.at("template").element_children
+          assert_nil remove.at("template")
+        end
 
-  test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on an Array of stream objects" do
-    message = Message.new(id: 1)
+        test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on an Array of stream objects" do
+          message = Message.new(id: 1)
 
-    message.broadcast_replace_to [message, :special]
-    message.broadcast_remove_to [message, :special]
-    replace, remove, *rest = capture_turbo_stream_broadcasts [message, :special]
+          message.broadcast_replace_to [message, :special]
+          message.broadcast_remove_to [message, :special]
+          replace, remove, *rest = capture_turbo_stream_broadcasts [message, :special]
 
-    assert_empty rest
-    assert_equal "replace", replace["action"]
-    assert_equal "remove", remove["action"]
-    assert_not_empty replace.at("template").element_children
-    assert_nil remove.at("template")
-  end
+          assert_empty rest
+          assert_equal "replace", replace["action"]
+          assert_equal "remove", remove["action"]
+          assert_not_empty replace.at("template").element_children
+          assert_nil remove.at("template")
+        end
 
-  test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream name from a block" do
-    message = Message.new(id: 1)
+        test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream name from a block" do
+          message = Message.new(id: 1)
 
-    replace, remove, *rest = capture_turbo_stream_broadcasts "messages" do
-      message.broadcast_replace_to "messages"
-      message.broadcast_remove_to "messages"
-    end
+          replace, remove, *rest = capture_turbo_stream_broadcasts "messages" do
+            message.broadcast_replace_to "messages"
+            message.broadcast_remove_to "messages"
+          end
 
-    assert_equal "replace", replace["action"]
-    assert_equal "remove", remove["action"]
-    assert_empty rest
-  end
+          assert_equal "replace", replace["action"]
+          assert_equal "remove", remove["action"]
+          assert_empty rest
+        end
 
-  test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream object from a block" do
-    message = Message.new(id: 1)
+        test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream object from a block" do
+          message = Message.new(id: 1)
 
-    replace, remove, *rest = capture_turbo_stream_broadcasts message do
-      message.broadcast_replace
-      message.broadcast_remove
-    end
+          replace, remove, *rest = capture_turbo_stream_broadcasts message do
+            message.broadcast_replace
+            message.broadcast_remove
+          end
 
-    assert_empty rest
-    assert_equal "replace", replace["action"]
-    assert_equal "remove", remove["action"]
-    assert_not_empty replace.at("template").element_children
-    assert_nil remove.at("template")
-  end
+          assert_empty rest
+          assert_equal "replace", replace["action"]
+          assert_equal "remove", remove["action"]
+          assert_not_empty replace.at("template").element_children
+          assert_nil remove.at("template")
+        end
 
-  test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on an Array of stream objects from a block" do
-    message = Message.new(id: 1)
+        test "#capture_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on an Array of stream objects from a block" do
+          message = Message.new(id: 1)
 
-    replace, remove, *rest = capture_turbo_stream_broadcasts [message, :special] do
-      message.broadcast_replace_to [message, :special]
-      message.broadcast_remove_to [message, :special]
-    end
+          replace, remove, *rest = capture_turbo_stream_broadcasts [message, :special] do
+            message.broadcast_replace_to [message, :special]
+            message.broadcast_remove_to [message, :special]
+          end
 
-    assert_empty rest
-    assert_equal "replace", replace["action"]
-    assert_equal "remove", remove["action"]
-    assert_not_empty replace.at("template").element_children
-    assert_nil remove.at("template")
-  end
+          assert_empty rest
+          assert_equal "replace", replace["action"]
+          assert_equal "remove", remove["action"]
+          assert_not_empty replace.at("template").element_children
+          assert_nil remove.at("template")
+        end
 
-  test "#capture_turbo_stream_broadcasts returns an empty Array when no broadcasts happened on a stream name from a block" do
-    streams = capture_turbo_stream_broadcasts "messages" do
-      # no-op
-    end
+        test "#capture_turbo_stream_broadcasts returns an empty Array when no broadcasts happened on a stream name from a block" do
+          streams = capture_turbo_stream_broadcasts "messages" do
+            # no-op
+          end
 
-    assert_empty streams
-  end
-end
-
-class Turbo::Broadcastable::TestHelper::AssertTurboStreamBroadcastsTest < ActiveSupport::TestCase
-  include Turbo::Broadcastable::TestHelper
-
-  test "#assert_turbo_stream_broadcasts passes when there is a broadcast" do
-    message = Message.new(id: 1)
-
-    message.broadcast_replace_to "messages"
-
-    assert_turbo_stream_broadcasts "messages"
-  end
-
-  test "#assert_turbo_stream_broadcasts passes when there are multiple broadcasts" do
-    message = Message.new(id: 1)
-
-    message.broadcast_replace_to "messages"
-    message.broadcast_remove_to "messages"
-
-    assert_turbo_stream_broadcasts "messages"
-  end
-
-  test "#assert_turbo_stream_broadcasts fails when no broadcasts happened on a stream name" do
-    assert_raises Minitest::Assertion do
-      assert_turbo_stream_broadcasts "messages"
-    end
-  end
-
-  test "#assert_turbo_stream_broadcasts with a count: optional fails when no broadcasts happened on a stream name" do
-    singular_failure = assert_raises Minitest::Assertion do
-      assert_turbo_stream_broadcasts "messages", count: 1
-    end
-
-    assert_includes singular_failure.message, %(1 Turbo Stream broadcast on "messages")
-
-    plural_failure = assert_raises Minitest::Assertion do
-      assert_turbo_stream_broadcasts "messages", count: 2
-    end
-
-    assert_includes plural_failure.message, %(2 Turbo Stream broadcasts on "messages")
-  end
-
-  test "#assert_turbo_stream_broadcasts passes when broadcast on a stream object" do
-    message = Message.new(id: 1)
-
-    message.broadcast_replace
-    message.broadcast_remove
-
-    assert_turbo_stream_broadcasts message, count: 2
-  end
-
-  test "#assert_turbo_stream_broadcasts passes when broadcast on an Array of stream objects" do
-    message = Message.new(id: 1)
-
-    message.broadcast_replace_to [message, :special]
-    message.broadcast_remove_to [message, :special]
-
-    assert_turbo_stream_broadcasts [message, :special], count: 2
-  end
-
-  test "#assert_turbo_stream_broadcasts with a count: option passes when broadcast on a stream name from a block" do
-    message = Message.new(id: 1)
-
-    assert_turbo_stream_broadcasts "messages", count: 2 do
-      message.broadcast_replace_to "messages"
-      message.broadcast_remove_to "messages"
-    end
-  end
-
-  test "#assert_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream object from a block" do
-    message = Message.new(id: 1)
-
-    assert_turbo_stream_broadcasts message, count: 2 do
-      message.broadcast_replace
-      message.broadcast_remove
-    end
-  end
-
-  test "#assert_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on an Array of stream objects from a block" do
-    message = Message.new(id: 1)
-
-    assert_turbo_stream_broadcasts [message, :special], count: 2 do
-      message.broadcast_replace_to [message, :special]
-      message.broadcast_remove_to [message, :special]
-    end
-  end
-
-  test "#assert_turbo_stream_broadcasts fails when no broadcasts happened on a stream name from a block" do
-    assert_raises Minitest::Assertion do
-      assert_turbo_stream_broadcasts "messages" do
-        # no-op
+          assert_empty streams
+        end
       end
-    end
-  end
-end
 
-class Turbo::Broadcastable::TestHelper::AssertNoTurboStreamBroadcastsTest < ActiveSupport::TestCase
-  include Turbo::Broadcastable::TestHelper
+      class Turbo::Broadcastable::TestHelper::AssertTurboStreamBroadcastsTest < ActiveSupport::TestCase
+        include Turbo::Broadcastable::TestHelper
 
-  test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream name" do
-    assert_no_turbo_stream_broadcasts "messages"
-  end
+        test "#assert_turbo_stream_broadcasts passes when there is a broadcast" do
+          message = Message.new(id: 1)
 
-  test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream name from a block" do
-    assert_no_turbo_stream_broadcasts "messages" do
-      # no-op
-    end
-  end
+          message.broadcast_replace_to "messages"
 
-  test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream object" do
-    message = Message.new(id: 1)
+          assert_turbo_stream_broadcasts "messages"
+        end
 
-    assert_no_turbo_stream_broadcasts message
-  end
+        test "#assert_turbo_stream_broadcasts passes when there are multiple broadcasts" do
+          message = Message.new(id: 1)
 
-  test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream object from a block" do
-    message = Message.new(id: 1)
+          message.broadcast_replace_to "messages"
+          message.broadcast_remove_to "messages"
 
-    assert_no_turbo_stream_broadcasts message do
-      # no-op
-    end
-  end
+          assert_turbo_stream_broadcasts "messages"
+        end
 
-  test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream name" do
-    message = Message.new(id: 1)
+        test "#assert_turbo_stream_broadcasts fails when no broadcasts happened on a stream name" do
+          assert_raises Minitest::Assertion do
+            assert_turbo_stream_broadcasts "messages"
+          end
+        end
 
-    assert_raises Minitest::Assertion do
-      message.broadcast_remove_to "messages"
+        test "#assert_turbo_stream_broadcasts with a count: optional fails when no broadcasts happened on a stream name" do
+          singular_failure = assert_raises Minitest::Assertion do
+            assert_turbo_stream_broadcasts "messages", count: 1
+          end
 
-      assert_no_turbo_stream_broadcasts "messages"
-    end
-  end
+          assert_includes singular_failure.message, %(1 Turbo Stream broadcast on "messages")
 
-  test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream name from a block" do
-    message = Message.new(id: 1)
+          plural_failure = assert_raises Minitest::Assertion do
+            assert_turbo_stream_broadcasts "messages", count: 2
+          end
 
-    assert_raises Minitest::Assertion do
-      assert_no_turbo_stream_broadcasts "messages" do
-        message.broadcast_remove_to "messages"
+          assert_includes plural_failure.message, %(2 Turbo Stream broadcasts on "messages")
+        end
+
+        test "#assert_turbo_stream_broadcasts passes when broadcast on a stream object" do
+          message = Message.new(id: 1)
+
+          message.broadcast_replace
+          message.broadcast_remove
+
+          assert_turbo_stream_broadcasts message, count: 2
+        end
+
+        test "#assert_turbo_stream_broadcasts passes when broadcast on an Array of stream objects" do
+          message = Message.new(id: 1)
+
+          message.broadcast_replace_to [message, :special]
+          message.broadcast_remove_to [message, :special]
+
+          assert_turbo_stream_broadcasts [message, :special], count: 2
+        end
+
+        test "#assert_turbo_stream_broadcasts with a count: option passes when broadcast on a stream name from a block" do
+          message = Message.new(id: 1)
+
+          assert_turbo_stream_broadcasts "messages", count: 2 do
+            message.broadcast_replace_to "messages"
+            message.broadcast_remove_to "messages"
+          end
+        end
+
+        test "#assert_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on a stream object from a block" do
+          message = Message.new(id: 1)
+
+          assert_turbo_stream_broadcasts message, count: 2 do
+            message.broadcast_replace
+            message.broadcast_remove
+          end
+        end
+
+        test "#assert_turbo_stream_broadcasts returns <turbo-stream> elements broadcast on an Array of stream objects from a block" do
+          message = Message.new(id: 1)
+
+          assert_turbo_stream_broadcasts [message, :special], count: 2 do
+            message.broadcast_replace_to [message, :special]
+            message.broadcast_remove_to [message, :special]
+          end
+        end
+
+        test "#assert_turbo_stream_broadcasts fails when no broadcasts happened on a stream name from a block" do
+          assert_raises Minitest::Assertion do
+            assert_turbo_stream_broadcasts "messages" do
+              # no-op
+            end
+          end
+        end
       end
-    end
-  end
 
-  test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream object" do
-    message = Message.new(id: 1)
+      class Turbo::Broadcastable::TestHelper::AssertNoTurboStreamBroadcastsTest < ActiveSupport::TestCase
+        include Turbo::Broadcastable::TestHelper
 
-    assert_raises Minitest::Assertion do
-      message.broadcast_remove
+        test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream name" do
+          assert_no_turbo_stream_broadcasts "messages"
+        end
 
-      assert_no_turbo_stream_broadcasts message
-    end
-  end
+        test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream name from a block" do
+          assert_no_turbo_stream_broadcasts "messages" do
+            # no-op
+          end
+        end
 
-  test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream object from a block" do
-    message = Message.new(id: 1)
+        test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream object" do
+          message = Message.new(id: 1)
 
-    assert_raises Minitest::Assertion do
-      assert_no_turbo_stream_broadcasts message do
-        message.broadcast_remove
+          assert_no_turbo_stream_broadcasts message
+        end
+
+        test "#assert_no_turbo_stream_broadcasts asserts no broadcasts with a stream object from a block" do
+          message = Message.new(id: 1)
+
+          assert_no_turbo_stream_broadcasts message do
+            # no-op
+          end
+        end
+
+        test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream name" do
+          message = Message.new(id: 1)
+
+          assert_raises Minitest::Assertion do
+            message.broadcast_remove_to "messages"
+
+            assert_no_turbo_stream_broadcasts "messages"
+          end
+        end
+
+        test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream name from a block" do
+          message = Message.new(id: 1)
+
+          assert_raises Minitest::Assertion do
+            assert_no_turbo_stream_broadcasts "messages" do
+              message.broadcast_remove_to "messages"
+            end
+          end
+        end
+
+        test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream object" do
+          message = Message.new(id: 1)
+
+          assert_raises Minitest::Assertion do
+            message.broadcast_remove
+
+            assert_no_turbo_stream_broadcasts message
+          end
+        end
+
+        test "#assert_no_turbo_stream_broadcasts fails when when a broadcast happened on a stream object from a block" do
+          message = Message.new(id: 1)
+
+          assert_raises Minitest::Assertion do
+            assert_no_turbo_stream_broadcasts message do
+              message.broadcast_remove
+            end
+          end
+        end
       end
     end
   end

--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.6.0"
 
-  s.add_dependency "activejob", ">= 6.0.0"
   s.add_dependency "actionpack", ">= 6.0.0"
   s.add_dependency "railties", ">= 6.0.0"
 


### PR DESCRIPTION
Fixes https://github.com/hotwired/turbo-rails/issues/478

Replaces https://github.com/hotwired/turbo-rails/pull/479

Based on https://github.com/hotwired/turbo-rails/pull/601