### PR TITLE
Only pass `:request_id` option to Refresh Stream

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -508,7 +508,7 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self, request_id: Turbo.current_request_id).compact
+        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self).compact
 
         if o[:html] || o[:partial]
           return o

--- a/test/dummy/app/views/messages/_message.html.erb
+++ b/test/dummy/app/views/messages/_message.html.erb
@@ -1,1 +1,3 @@
+<%# locals: (message:, profile: nil) %>
+
 <p><%= message %></p>


### PR DESCRIPTION
When rendering `<turbo-stream>` elements for broadcasting, **omit** the `:request_id` partial-local variable if it's blank.

If rendered partials utilize [Action View strict locals][], the extra variable raises an error:

```
unknown local :request_id
```

By omitting the `:request_id` from the
`Turbo::Broadcastable#broadcast_rendering_with_defaults`, it isn't passed as part of partial rendering.

Since `broadcast_refresh` never renders a partial itself (it builds an empty `<turbo-stream action="refresh"
request-id="..."></turbo-stream>` element), the `:request_id` local variable isn't necessary.

[Action view strict locals]: https://guides.rubyonrails.org/action_view_overview.html#strict-locals