### PR TITLE
Bump version for 2.0.6

### DIFF
--- a/lib/turbo/version.rb
+++ b/lib/turbo/version.rb
@@ -1,3 +1,3 @@
 module Turbo
-  VERSION = "2.0.5"
+  VERSION = "2.0.6"
 end


### PR DESCRIPTION
The error related with this PR https://github.com/hotwired/turbo-rails/issues/512 still exists as there is not any new release of the gem.

Let's bump the version to 2.0.6 and generate a new release.