### PR TITLE
Adds external_link_to helper to navigate outside of a turbo-frame

### DIFF
--- a/app/helpers/turbo/link_to_helper.rb
+++ b/app/helpers/turbo/link_to_helper.rb
@@ -1,0 +1,13 @@
+module Turbo::LinkToHelper
+  # Allows creation of a link that can navigate outside of the turbo frame:
+  #
+  #   <%= external_link_to "Click me", "https://example.com" %>
+  #
+  # This will render:
+  #
+  #  <a href="https://example.com" target="_top">Click me</a>
+  def external_link_to(*args, **options, &block)
+    options[:target] = "_top"
+    link_to(*args, **options, &block)
+  end
+end


### PR DESCRIPTION
SEEKING FEEDBACK:

I feel that it would be a clearer API for newer users to have an explicit `external_link_to` method instead of defining `link_to "..", target: "_top"` every time they want to link outside of a turbo-frame.

If this is accepted by maintainers I will add tests and can tweak the documentation if needed.