### PR TITLE
Pass a String to ActiveJob (rather than a SafeBuffer)

### DIFF
--- a/app/jobs/turbo/streams/broadcast_stream_job.rb
+++ b/app/jobs/turbo/streams/broadcast_stream_job.rb
@@ -4,4 +4,8 @@ class Turbo::Streams::BroadcastStreamJob < ActiveJob::Base
   def perform(stream, content:)
     Turbo::StreamsChannel.broadcast_stream_to(stream, content: content)
   end
+
+  def self.perform_later(stream, content:)
+    super(stream, content: content.to_str)
+  end
 end


### PR DESCRIPTION
This provides compatibility with Sidekiq as an ActiveJob adapter (because [Sidekiq only allows native JSON types][1] to be passed as job arguments).

All credit goes to [@jdelStrother] who [suggested this solution][2].

Fixes [#522], fixes [#535]

[1]: https://github.com/sidekiq/sidekiq/wiki/Best-Practices#1-make-your-job-parameters-small-and-simple
[2]: https://github.com/hotwired/turbo-rails/issues/535#issuecomment-1946805651
[@jdelStrother]: https://github.com/jdelStrother
[#522]: https://github.com/hotwired/turbo-rails/issues/522
[#535]: https://github.com/hotwired/turbo-rails/issues/535