### PR TITLE
Automatically add turbo frame tag on turbo frame responses

### DIFF
--- a/app/views/layouts/turbo_rails/frame.html.erb
+++ b/app/views/layouts/turbo_rails/frame.html.erb
@@ -3,6 +3,8 @@
     <%= yield :head %>
   </head>
   <body>
-    <%= yield %>
+    <%= turbo_frame_tag turbo_frame_request_id do %>
+      <%= yield %>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
## Description

This change allows views to be agnostic on where they are going to render.

As an example, I could have an `/articles/new` endpoint which I can access directly through the URL and renders

```ruby
# app/views/articles/new.html.erb
<%= render 'form', article: @article %>
```

if later on, I want to display the form in a modal/sheet/panel I wouldn't need to change anything specific. Assuming the modal/sheet/panel is implemented as a Turbo Frame that loads content when clicking a button/link, then we can trigger a call to `/articles/new` with `data-turbo-frame='modal'` and everything just works. This change takes care of automatically wrapping the response on a turbo frame tag with with the frame id that was sent by the requester.

I'm wondering if I'm missing something, but this sounds like a good default to me 🤔 