### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/turbo-rails

### DIFF
--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.add_dependency "railties", ">= 6.0.0"
 
   s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+
+  s.metadata["changelog_uri"] = "https://github.com/hotwired/turbo-rails/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/turbo-rails which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/