### PR TITLE
Support broadcast_remove_to with options

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -241,8 +241,8 @@ module Turbo::Broadcastable
   #
   #   # Sends <turbo-stream action="remove" target="clearance_5"></turbo-stream> to the stream named "identity:2:clearances"
   #   clearance.broadcast_remove_to examiner.identity, :clearances
-  def broadcast_remove_to(*streamables, target: self)
-    Turbo::StreamsChannel.broadcast_remove_to(*streamables, target: target) unless suppressed_turbo_broadcasts?
+  def broadcast_remove_to(*streamables, **rendering)
+    Turbo::StreamsChannel.broadcast_remove_to(*streamables, target: self, **rendering) unless suppressed_turbo_broadcasts?
   end
 
   # Same as <tt>#broadcast_remove_to</tt>, but the designated stream is automatically set to the current model.

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -31,6 +31,18 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting remove to stream now with a targets" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("remove", target: 'message_1') do
+      @message.broadcast_remove_to "stream", target: 'message_1'
+    end
+  end
+
+  test "broadcasting remove to stream now with multiple targets" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("remove", target: nil, targets: '.message_1') do
+      @message.broadcast_remove_to "stream", target: nil, targets: ".message_1"
+    end
+  end
+
   test "broadcasting remove now" do
     assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("remove", target: "message_1") do
       @message.broadcast_remove


### PR DESCRIPTION
Make `broadcast_remove_to` behavior consistent with other `broadcast_*_to` methods by allowing keyword arguments to be passed down to `broadcast_action_to`.

The main use case is supporting multiple targets for broadcast_remove_to like other methods do.
i.e.: `broadcast_remove_to *streamables, target: nil, targets: '.css-class-name'`

Options are supported by the method called downstream:
broadcastable.rb
<img width="834" alt="image" src="https://github.com/hotwired/turbo-rails/assets/47999699/790dc346-8976-4728-9f90-e0c4b7f2b5a8">
broadcasts.rb
<img width="479" alt="image" src="https://github.com/hotwired/turbo-rails/assets/47999699/3be345a5-62dd-416e-bb2f-ae3d42f548a7">

Here are some existing examples of other `broadcast_*_to` methods following similar patterns to the change made:

broadcast_update_to:
<img width="1147" alt="image" src="https://github.com/hotwired/turbo-rails/assets/47999699/5f779e34-e0f5-40fb-a981-1b1ea20a200a">

broadcast_replace_to:
<img width="1154" alt="image" src="https://github.com/hotwired/turbo-rails/assets/47999699/3f5ed0ab-ef0b-40ff-a74f-86f7a47b0c00">
