### PR TITLE
CI: bump Ferrum/Chrome timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           - { ruby: "head", rails: "main", allow-fail: true }
 
     env:
+      FERRUM_PROCESS_TIMEOUT: 25
+      FERRUM_DEFAULT_TIMEOUT: 15
       RAILS_VERSION: "${{ matrix.rails }}"
 
     name: ${{ format('Tests (Ruby {0}, Rails {1})', matrix.ruby, matrix.rails) }}


### PR DESCRIPTION
This error is common in CI:

      1) Error:
    BroadcastsTest#test_Message_broadcasts_with_renderable:_render_option:
    Ferrum::ProcessTimeoutError: Browser did not produce websocket url
    within 10 seconds, try to increase `:process_timeout`. See
    https://github.com/rubycdp/ferrum#customization

Example: https://github.com/hotwired/turbo-rails/actions/runs/9919129989/job/27404623838#step:4:230

It is possible to control this timeout (and another one) via ENV vars: https://github.com/rubycdp/ferrum/blob/v0.15/lib/ferrum/browser/options.rb#L10-L11

"timeout" is

> The number of seconds we'll wait for a response when communicating with browser. Default is 5.

"process_timeout" is (defaults to 10)

> How long to wait for the Chrome process to respond on startup.

Both ferrum CI and cuprite CI has the timeouts set to 25 and 15:

* https://github.com/rubycdp/ferrum/blob/19767d0885afbebc95574eda685e04dc9da2b47d/.github/workflows/tests.yml#L16-L18
* https://github.com/rubycdp/cuprite/blob/373b894d723bf9fb1afe31781963fe655a177218/.github/workflows/tests.yml#L16-L18