### PR TITLE
Remove morph broadcast helpers

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -107,14 +107,6 @@ module Turbo::Streams::Broadcasts
     Turbo::ThreadDebouncer.for("turbo-refresh-debouncer-#{stream_name_from(streamables.including(request_id))}")
   end
 
-  def broadcast_morph_to(*streamables, **opts)
-    broadcast_action_to(*streamables, action: :morph, **opts)
-  end
-
-  def broadcast_morph_later_to(*streamables, **opts)
-    broadcast_action_later_to(*streamables, action: :morph, **opts)
-  end
-
   private
     def render_format(format, **rendering)
       ApplicationController.render(formats: [ format ], **rendering)

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -260,6 +260,10 @@ module Turbo::Broadcastable
   #   # Sends <turbo-stream action="replace" target="clearance_5"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_replace_to examiner.identity, :clearances, partial: "clearances/other_partial", locals: { a: 1 }
+  #
+  #   # Sends <turbo-stream action="replace" method="morph" target="clearance_5"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   clearance.broadcast_replace_to examiner.identity, :clearance, attributes: { method: :morph }, partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_replace_to(*streamables, **rendering)
     Turbo::StreamsChannel.broadcast_replace_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
   end
@@ -279,6 +283,10 @@ module Turbo::Broadcastable
   #   # Sends <turbo-stream action="update" target="clearance_5"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
   #   # to the stream named "identity:2:clearances"
   #   clearance.broadcast_update_to examiner.identity, :clearances, partial: "clearances/other_partial", locals: { a: 1 }
+  #
+  #   # sends <turbo-stream action="update" method="morph" target="clearance_5"><template><div id="clearance_5">Other partial</div></template></turbo-stream>
+  #   # to the stream named "identity:2:clearances"
+  #   # clearance.broadcast_update_to examiner.identity, :clearances, attributes: { method: :morph }, partial: "clearances/other_partial", locals: { a: 1 }
   def broadcast_update_to(*streamables, **rendering)
     Turbo::StreamsChannel.broadcast_update_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
   end
@@ -489,29 +497,6 @@ module Turbo::Broadcastable
   # <tt>streamables</tt>.
   def broadcast_render_later_to(*streamables, **rendering)
     Turbo::StreamsChannel.broadcast_render_later_to(*streamables, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
-  end
-
-  # Broadcast a morph action to the stream name identified by the passed <tt>streamables</tt>. Example:
-  # sends <turbo-stream action="morph" target="clearance_5"><template><div id="clearance_5">My Clearance</div></template></turbo-stream>
-  # to the stream named "identity:2:clearances"
-  # clearance.broadcast_morph_to examiner.identity, :clearances
-  def broadcast_morph_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_morph_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
-  end
-
-  # Same as <tt>broadcast_morph_to</tt> but the designated stream is automatically set to the current model.
-  def broadcast_morph(**rendering)
-    broadcast_morph_to(self, target: self, **rendering)
-  end
-
-  # Same as <tt>broadcast_morph_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
-  def broadcast_morph_later_to(*streamables, **rendering)
-    Turbo::StreamsChannel.broadcast_morph_later_to(*streamables, target: self, **broadcast_rendering_with_defaults(rendering)) unless suppressed_turbo_broadcasts?
-  end
-
-  # Same as <tt>broadcast_morph_later_to</tt> but the designated stream is automatically set to the current model.
-  def broadcast_morph_later(target: broadcast_target_default, **rendering)
-    broadcast_morph_later_to self, **rendering
   end
 
   private

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -244,27 +244,27 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
-  test "broadcasting morph to stream now" do
-    assert_broadcast_on "stream", turbo_stream_action_tag("morph", target: "message_1", template: render(@message)) do
-      @message.broadcast_morph_to "stream", target: "message_1"
+  test "broadcasting replace morph to stream now" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("replace", target: "message_1", method: :morph, template: render(@message)) do
+      @message.broadcast_replace_to "stream", target: "message_1", attributes: { method: :morph }
     end
   end
 
-  test "broadcasting morph to stream now targeting children-only children-only" do
-    assert_broadcast_on "stream", turbo_stream_action_tag("morph", target: "message_1", 'children-only': true, template: render(@message)) do
-      @message.broadcast_morph_to "stream", target: "message_1", attributes: { 'children-only': true }
-    end
-  end
-  
-  test "broadcasting morph now" do
-    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("morph", target: "message_1", template: render(@message)) do
-      @message.broadcast_morph target: "message_1"
+  test "broadcasting update morph to stream now targeting" do
+    assert_broadcast_on "stream", turbo_stream_action_tag("update", target: "message_1", method: :morph, template: render(@message)) do
+      @message.broadcast_update_to "stream", target: "message_1", attributes: { method: :morph }
     end
   end
 
-  test "broadcasting morph now targeting children-only" do
-    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("morph", target: "message_1", 'children-only': true, template: render(@message)) do
-      @message.broadcast_morph target: "message_1", attributes: { 'children-only': true }
+  test "broadcasting replace morph now" do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("replace", target: "message_1", method: :morph, template: render(@message)) do
+      @message.broadcast_replace target: "message_1", attributes: { method: :morph }
+    end
+  end
+
+  test "broadcasting update morph now" do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_action_tag("update", target: "message_1", method: :morph, template: render(@message)) do
+      @message.broadcast_update target: "message_1", attributes: { method: :morph }
     end
   end
 end
@@ -558,30 +558,6 @@ class Turbo::SuppressingBroadcastsTest < ActionCable::Channel::TestCase
     @profile = Users::Profile.new(id: 1, name: "Ryan")
     assert_no_broadcasts_later_when_supressing do
       @message.broadcast_render_to @profile
-    end
-  end
-
-  test "suppressing broadcasting morph to stream now" do
-    assert_no_broadcasts_when_suppressing do
-      @message.broadcast_morph_to "stream"
-    end
-  end
-  
-  test "suppressing broadcasting morph to stream later" do
-    assert_no_broadcasts_later_when_supressing do
-      @message.broadcast_morph_later_to "stream"
-    end
-  end
-  
-  test "suppressing broadcasting morph now" do
-    assert_no_broadcasts_when_suppressing do
-      @message.broadcast_morph
-    end
-  end
-  
-  test "suppressing broadcasting morph later" do
-    assert_no_broadcasts_later_when_supressing do
-      @message.broadcast_morph_later
     end
   end
 

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -286,31 +286,53 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
     end
   end
 
-  test "broadcasting morph now" do
-    options = { partial: "messages/message", locals: { message: "hello!" } }
-  
-    assert_broadcast_on "stream", turbo_stream_action_tag("morph", target: "message_1", template: render(options)) do
-      Turbo::StreamsChannel.broadcast_morph_to "stream", target: "message_1", **options
+  test "broadcasting actions with method morph now" do
+    options = { attributes: { method: :morph }, partial: "messages/message", locals: { message: "hello!" } }
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("replace", target: "message_1", method: :morph, template: render(options)) do
+      Turbo::StreamsChannel.broadcast_replace_to "stream", target: "message_1", **options
     end
-  
-    assert_broadcast_on "stream", turbo_stream_action_tag("morph", targets: ".message", template: render(options)) do
-      Turbo::StreamsChannel.broadcast_morph_to "stream", targets: ".message", **options
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("replace", targets: ".message", method: :morph,template: render(options)) do
+      Turbo::StreamsChannel.broadcast_replace_to "stream", targets: ".message", **options
+    end
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("update", target: "message_1", method: :morph, template: render(options)) do
+      Turbo::StreamsChannel.broadcast_update_to "stream", target: "message_1", **options
+    end
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("update", targets: ".message", method: :morph, template: render(options)) do
+      Turbo::StreamsChannel.broadcast_update_to "stream", targets: ".message", **options
     end
   end
-  
-  test "broadcasting morph later" do
-    options = { partial: "messages/message", locals: { message: "hello!" } }
-  
-    assert_broadcast_on "stream", turbo_stream_action_tag("morph", target: "message_1", template: render(options)) do
+
+  test "broadcasting actions with method morph later" do
+    options = { attributes: { method: :morph }, partial: "messages/message", locals: { message: "hello!" } }
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("replace", target: "message_1", method: :morph, template: render(options)) do
       perform_enqueued_jobs do
-        Turbo::StreamsChannel.broadcast_morph_later_to \
+        Turbo::StreamsChannel.broadcast_replace_later_to \
           "stream", target: "message_1", **options
       end
     end
-  
-    assert_broadcast_on "stream", turbo_stream_action_tag("morph", targets: ".message", template: render(options)) do
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("replace", targets: ".message", method: :morph, template: render(options)) do
       perform_enqueued_jobs do
-        Turbo::StreamsChannel.broadcast_morph_later_to \
+        Turbo::StreamsChannel.broadcast_replace_later_to \
+          "stream", targets: ".message", **options
+      end
+    end
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("update", target: "message_1", method: :morph, template: render(options)) do
+      perform_enqueued_jobs do
+        Turbo::StreamsChannel.broadcast_update_later_to \
+          "stream", target: "message_1", **options
+      end
+    end
+
+    assert_broadcast_on "stream", turbo_stream_action_tag("update", targets: ".message", method: :morph, template: render(options)) do
+      perform_enqueued_jobs do
+        Turbo::StreamsChannel.broadcast_update_later_to \
           "stream", targets: ".message", **options
       end
     end


### PR DESCRIPTION
Follow up to morph action API restructure by @seanpdoyle in https://github.com/hotwired/turbo/pull/1240
This PR Removes morph stream action broadcast helpers and updates unit test and documentation for morph usage 