### PR TITLE
Add minfied files to the package to allow them to be cached by a CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "module": "app/javascript/turbo/index.js",
   "main": "app/assets/javascripts/turbo.js",
   "files": [
-    "app/javascript/turbo"
+    "app/javascript/turbo",
+    "app/assets/javascripts"
   ],
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
Currently only `turbo.js` (and its source files) are added to the npm package. This means that CDNs only cache this file and not also the `turbo.min.js` file which would be preferable.

This change adds the `app/assets/turbo` folder to the files such that they are also added to the npm package.