### PR TITLE
Fix deprecation in routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get "recede_historical_location"  => "turbo/native/navigation#recede",  as: :turbo_recede_historical_location
-  get "resume_historical_location"  => "turbo/native/navigation#resume",  as: :turbo_resume_historical_location
-  get "refresh_historical_location" => "turbo/native/navigation#refresh", as: :turbo_refresh_historical_location
+  get "recede_historical_location", to: "turbo/native/navigation#recede",  as: :turbo_recede_historical_location
+  get "resume_historical_location", to: "turbo/native/navigation#resume",  as: :turbo_resume_historical_location
+  get "refresh_historical_location", to: "turbo/native/navigation#refresh", as: :turbo_refresh_historical_location
 end if Turbo.draw_routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get "recede_historical_location", to: "turbo/native/navigation#recede",  as: :turbo_recede_historical_location
+  get "recede_historical_location", to: "turbo/native/navigation#recede", as: :turbo_recede_historical_location
   get "resume_historical_location", to: "turbo/native/navigation#resume",  as: :turbo_resume_historical_location
   get "refresh_historical_location", to: "turbo/native/navigation#refresh", as: :turbo_refresh_historical_location
 end if Turbo.draw_routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get "recede_historical_location", to: "turbo/native/navigation#recede", as: :turbo_recede_historical_location
-  get "resume_historical_location", to: "turbo/native/navigation#resume",  as: :turbo_resume_historical_location
+  get "resume_historical_location", to: "turbo/native/navigation#resume", as: :turbo_resume_historical_location
   get "refresh_historical_location", to: "turbo/native/navigation#refresh", as: :turbo_refresh_historical_location
 end if Turbo.draw_routes


### PR DESCRIPTION
Fixes new deprecation in Rails from https://github.com/rails/rails/pull/52422 that marks paths as hash keys in routes for removal.