### PR TITLE
Raise ArgumentError when turbo_stream_from helper gets passed blank streamables

### DIFF
--- a/app/helpers/turbo/streams_helper.rb
+++ b/app/helpers/turbo/streams_helper.rb
@@ -49,12 +49,12 @@ module Turbo::StreamsHelper
   #
   #   <%= turbo_stream_from "room", channel: RoomChannel, data: {room_name: "room #1"} %>
   #
-  # Raises an +ArgumentError+ if any streamables are blank
+  # Raises an +ArgumentError+ if all streamables are blank
   #
   #   <%= turbo_stream_from("") %> # => ArgumentError: streamables can't be blank
-  #   <%= turbo_stream_from("channel", nil, "messages") %> # => ArgumentError: streamables can't be blank
+  #   <%= turbo_stream_from("", nil) %> # => ArgumentError: streamables can't be blank
   def turbo_stream_from(*streamables, **attributes)
-    raise ArgumentError, "streamables can't be blank" if streamables.any?(&:blank?)
+    raise ArgumentError, "streamables can't be blank" unless streamables.any?(&:present?)
     attributes[:channel] = attributes[:channel]&.to_s || "Turbo::StreamsChannel"
     attributes[:"signed-stream-name"] = Turbo::StreamsChannel.signed_stream_name(streamables)
 

--- a/app/helpers/turbo/streams_helper.rb
+++ b/app/helpers/turbo/streams_helper.rb
@@ -48,7 +48,13 @@ module Turbo::StreamsHelper
   # It is also possible to pass additional parameters to the channel by passing them through `data` attributes:
   #
   #   <%= turbo_stream_from "room", channel: RoomChannel, data: {room_name: "room #1"} %>
+  #
+  # Raises an +ArgumentError+ if any streamables are blank
+  #
+  #   <%= turbo_stream_from("") %> # => ArgumentError: streamables can't be blank
+  #   <%= turbo_stream_from("channel", nil, "messages") %> # => ArgumentError: streamables can't be blank
   def turbo_stream_from(*streamables, **attributes)
+    raise ArgumentError, "streamables can't be blank" if streamables.any?(&:blank?)
     attributes[:channel] = attributes[:channel]&.to_s || "Turbo::StreamsChannel"
     attributes[:"signed-stream-name"] = Turbo::StreamsChannel.signed_stream_name(streamables)
 

--- a/test/streams/streams_helper_test.rb
+++ b/test/streams/streams_helper_test.rb
@@ -11,6 +11,12 @@ class Turbo::StreamsHelperTest < ActionView::TestCase
       turbo_stream_from("messages")
   end
 
+  test "with multiple streamables, some blank" do
+    assert_dom_equal \
+      %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{Turbo::StreamsChannel.signed_stream_name(["channel", nil, "", "messages"])}"></turbo-cable-stream-source>),
+      turbo_stream_from("channel", nil, "", "messages")
+  end
+
   test "with invalid streamables" do
     assert_raises ArgumentError, "streamables can't be blank" do
       turbo_stream_from("")
@@ -21,11 +27,7 @@ class Turbo::StreamsHelperTest < ActionView::TestCase
     end
 
     assert_raises ArgumentError, "streamables can't be blank" do
-      turbo_stream_from("channel", nil, "messages")
-    end
-
-    assert_raises ArgumentError, "streamables can't be blank" do
-      turbo_stream_from("channel", "", "messages")
+      turbo_stream_from("", nil)
     end
   end
 

--- a/test/streams/streams_helper_test.rb
+++ b/test/streams/streams_helper_test.rb
@@ -11,6 +11,24 @@ class Turbo::StreamsHelperTest < ActionView::TestCase
       turbo_stream_from("messages")
   end
 
+  test "with invalid streamables" do
+    assert_raises ArgumentError, "streamables can't be blank" do
+      turbo_stream_from("")
+    end
+
+    assert_raises ArgumentError, "streamables can't be blank" do
+      turbo_stream_from(nil)
+    end
+
+    assert_raises ArgumentError, "streamables can't be blank" do
+      turbo_stream_from("channel", nil, "messages")
+    end
+
+    assert_raises ArgumentError, "streamables can't be blank" do
+      turbo_stream_from("channel", "", "messages")
+    end
+  end
+
   test "with streamable and html attributes" do
     assert_dom_equal \
       %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{Turbo::StreamsChannel.signed_stream_name("messages")}" data-stream-target="source"></turbo-cable-stream-source>),


### PR DESCRIPTION
Hi everyone,

When people pass in blank streamables into `turbo_stream_from` it can lead to unpredictable issues for i.e. the postgresql ActionCable adapter blowing up (postgresql's NOTIFY will throw an exception when passed in an empty string):
https://github.com/reclaim-the-stack/actioncable-enhanced-postgresql-adapter/issues/3 (this issue does also happen with the regular postgresql adapter - I ran into it myself).

I'm not sure if it is a little too overzealous here to prevent any of the passed in streamables from being blank. But I can't come up with a scenario where one might pass in a blank string or nil in between other streamables intentionally.