### PR TITLE
Restore support for `broadcast_refreshes` with Sidekiq's default  `strict_args`

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -78,7 +78,7 @@ module Turbo::Streams::Broadcasts
 
   def broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id, **opts)
     refresh_debouncer_for(*streamables, request_id: request_id).debounce do
-      Turbo::Streams::BroadcastStreamJob.perform_later stream_name_from(streamables), content: turbo_stream_refresh_tag(request_id: request_id, **opts)
+      Turbo::Streams::BroadcastStreamJob.perform_later stream_name_from(streamables), content: turbo_stream_refresh_tag(request_id: request_id, **opts).to_str # Sidekiq requires job arguments to be valid JSON types, such as String
     end
   end
 


### PR DESCRIPTION
Restores support for `broadcast_refreshes` when using Sidekiq in the default [`strict_args` mode](https://github.com/sidekiq/sidekiq/blob/2451d70080db95cb5f69effcbd74381cf3b3f727/docs/7.0-Upgrade.md#strict-arguments).

**Temporary Workaround:**
Until merge, this issue can be bypassed by disabling `strict_args`.

Original solution suggested by @jdelStrother [here](https://github.com/hotwired/turbo-rails/issues/535#issuecomment-1946805651).
Based on [PR 642](https://github.com/hotwired/turbo-rails/pull/624) by @michaelbaudino.

---

Fixes #522, fixes #535.
See discussion on [PR 642](https://github.com/hotwired/turbo-rails/pull/624) with @michaelbaudino and @dhh