### PR TITLE
Address `warning: `*' interpreted as argument prefix`

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -38,8 +38,8 @@ module Turbo::Streams::Broadcasts
   end
 
   def broadcast_action_to(*streamables, action:, target: nil, targets: nil, attributes: {}, **rendering)
-    broadcast_stream_to *streamables, content: turbo_stream_action_tag(
-      action, target: target, targets: targets, template: render_broadcast_action(rendering), **attributes
+    broadcast_stream_to(*streamables, content: turbo_stream_action_tag(
+      action, target: target, targets: targets, template: render_broadcast_action(rendering), **attributes)
     )
   end
 


### PR DESCRIPTION
This commit addresses the following warning appeared at Rails CI.

https://buildkite.com/rails/rails/builds/112102#01924ba4-ac89-4b7b-811d-6a6d37a241a1/1308-1314

```ruby
/usr/local/bundle/gems/turbo-rails-2.0.10/app/channels/turbo/streams/broadcasts.rb:41: warning: `*' interpreted as argument prefix
```

This line has been updated via this commit and released in v2.0.10 https://github.com/hotwired/turbo-rails/commit/595634e8223bba6f0314dc9a11068063fa807d5e