### PR TITLE
Migrate Turbo Native helpers to Hotwire Native

### DIFF
--- a/app/controllers/turbo/native/navigation.rb
+++ b/app/controllers/turbo/native/navigation.rb
@@ -1,20 +1,23 @@
 # Turbo is built to work with native navigation principles and present those alongside what's required for the web. When you
-# have Turbo Native clients running (see the Turbo iOS and Turbo Android projects for details), you can respond to native
-# requests with three dedicated responses: <tt>recede</tt>, <tt>resume</tt>, <tt>refresh</tt>.
+# have Hotwire Native clients running (see the Hotwire Native iOS and Hotwire Native Android projects for details),
+# you can respond to native requests with three dedicated responses: <tt>recede</tt>, <tt>resume</tt>, <tt>refresh</tt>.
 #
-# turbo-android handles these actions automatically. You are required to implement the handling on your own for turbo-ios.
+# Hotwire Native Android and Hotwire Native iOS handle these actions automatically.
 module Turbo::Native::Navigation
   extend ActiveSupport::Concern
 
   included do
-    helper_method :turbo_native_app?
+    helper_method :hotwire_native_app?, :turbo_native_app?
   end
 
-  # Turbo Native applications are identified by having the string "Turbo Native" as part of their user agent.
-  def turbo_native_app?
-    request.user_agent.to_s.match?(/Turbo Native/)
+  # Hotwire Native applications are identified by having the string "Hotwire Native" as part of their user agent.
+  # Legacy Turbo Native applications use the "Turbo Native" string.
+  def hotwire_native_app?
+    request.user_agent.to_s.match?(/(Turbo|Hotwire) Native/)
   end
-  
+
+  alias_method :turbo_native_app?, :hotwire_native_app?
+
   # Tell the Turbo Native app to dismiss a modal (if presented) or pop a screen off of the navigation stack. Otherwise redirect to the given URL if Turbo Native is not present.
   def recede_or_redirect_to(url, **options)
     turbo_native_action_or_redirect url, :recede, :to, options

--- a/test/native/navigation_controller_test.rb
+++ b/test/native/navigation_controller_test.rb
@@ -6,7 +6,7 @@ class Turbo::Native::NavigationControllerTest < ActionDispatch::IntegrationTest
       post trays_path, params: { return_to: "#{action}_or_redirect" }
       assert_redirected_to tray_path(id: 1)
 
-      post trays_path, params: { return_to: "#{action}_or_redirect" }, headers: header_for_turbo_native_app
+      post trays_path, params: { return_to: "#{action}_or_redirect" }, headers: header_for_hotwire_native_app
       assert_redirected_to send("turbo_#{action}_historical_location_url")
     end
   end
@@ -19,7 +19,7 @@ class Turbo::Native::NavigationControllerTest < ActionDispatch::IntegrationTest
       post trays_path, params: { return_to: "#{action}_or_redirect_back" }, headers: header_for_referer
       assert_redirected_to "/past_place"
 
-      post trays_path, params: { return_to: "#{action}_or_redirect_back" }, headers: header_for_turbo_native_app.merge(header_for_referer)
+      post trays_path, params: { return_to: "#{action}_or_redirect_back" }, headers: header_for_hotwire_native_app.merge(header_for_referer)
       assert_redirected_to send("turbo_#{action}_historical_location_url")
     end
   end
@@ -28,7 +28,7 @@ class Turbo::Native::NavigationControllerTest < ActionDispatch::IntegrationTest
     post trays_path, params: { return_to: "refresh_or_redirect_with_options" }
     assert_redirected_to tray_path(id: 5)
 
-    post trays_path, params: { return_to: "refresh_or_redirect_with_options" }, headers: header_for_turbo_native_app
+    post trays_path, params: { return_to: "refresh_or_redirect_with_options" }, headers: header_for_hotwire_native_app
     assert_redirected_to send("turbo_refresh_historical_location_url", notice: "confirmed", custom: 123)
   end
 
@@ -40,8 +40,8 @@ class Turbo::Native::NavigationControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
-    def header_for_turbo_native_app
-      { "HTTP_USER_AGENT" => "MyApp iOS/3.0 Turbo Native (build 13; iPad Air 2); iOS 9.3" }
+    def header_for_hotwire_native_app
+      { "HTTP_USER_AGENT" => "MyApp iOS/3.0 Hotwire Native (build 13; iPad Air 2); iOS 9.3" }
     end
 
     def header_for_referer


### PR DESCRIPTION
This PR renames the `turbo_native_app?` helper to `hotwire_native_app?` and changes the user agent check to look for "Hotwire Native".

It is backwards compatible with existing Turbo Native apps by aliasing the `turbo_native_app?` helper and also checking for "Turbo Native" in the user agent.