### PR TITLE
Update to rack 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,7 @@ gem "sprockets-rails"
 gem 'rake'
 gem 'byebug'
 gem 'puma'
-
-# For edge Rails, don't use Rack 3 yet.
-# Remove this when https://github.com/rails/rails/pull/46594 has merged.
-gem 'rack', '< 3'
+gem 'rack'
 
 group :development, :test do
   gem 'importmap-rails'


### PR DESCRIPTION
This was previously blocked, see https://github.com/rails/rails/pull/46594.

Rails 7.1 now supports rack 3 and Capybara assumes rack 3, making tests fail when run via rake (but not bin/test).