### PR TITLE
Include CSRF `<meta>` elements in frame layout

### DIFF
--- a/app/views/layouts/turbo_rails/frame.html.erb
+++ b/app/views/layouts/turbo_rails/frame.html.erb
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <%= csrf_meta_tags %>
     <%= yield :head %>
   </head>
   <body>

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery
 end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -14,6 +14,8 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "head", count: 1
     assert_select "meta[name=test][content=present]"
+    assert_select "meta[name=csrf-param]"
+    assert_select "meta[name=csrf-token]"
   end
 
   test "frame request layout can be overridden" do


### PR DESCRIPTION
Closes [#669][]

If a response to a request with the `Turbo-Frame:` header does not include the `<meta>` elements in the `<html>` document, it's likely that the browser will remove any `<meta>` element present after handling navigating the `<turbo-frame>` that originated the request.

In support of testing this behavior, this commit enables CSRF protection in the test suite.

[#669]: https://github.com/hotwired/turbo-rails/issues/669