### PR TITLE
Drop Support for `ruby@2.x.x`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ "6.1", "7.0", "7.1", "7.2" ]
-        ruby: [ "2.7", "3.0", "3.1", "3.2", "3.3" ]
+        rails: [ "7.1", "7.2", "8.0" ]
+        ruby: [ "3.1", "3.2", "3.3", "3.4" ]
         allow-fail: [ false ]
         include:
-          - { ruby: "2.6",  rails: "6.1" }
           - { ruby: "3.3",  rails: "main", allow-fail: true }
           - { ruby: "3.2",  rails: "main", allow-fail: true }
           - { ruby: "head", rails: "main", allow-fail: true }
         exclude:
-          - { ruby: "2.7", rails: "7.2" }
-          - { ruby: "3.0", rails: "7.2" }
+          - { ruby: "3.1", rails: "8.0" }
 
     env:
       FERRUM_PROCESS_TIMEOUT: 25
@@ -37,7 +35,6 @@ jobs:
 
       - name: Run Bug Template Tests
         run: ruby bug_report_template.rb || ruby bug_report_template.rb
-        continue-on-error: ${{ startsWith(matrix.ruby, '2') || false }}
 
       - name: Run tests
         id: test

--- a/Gemfile
+++ b/Gemfile
@@ -15,21 +15,11 @@ gem "sprockets-rails"
 
 gem 'rake'
 gem 'byebug'
-
-if RUBY_VERSION < "3"
-  gem "rack", "< 3"
-  gem "puma", "< 6"
-else
-  gem "rack"
-  gem "puma"
-end
+gem 'puma'
+gem 'rack'
 
 group :development, :test do
-  if rails_version == "6.1"
-    gem "importmap-rails", "0.6.1"
-  else
-    gem "importmap-rails"
-  end
+  gem 'importmap-rails'
 end
 
 group :test do

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -38,8 +38,6 @@ module Turbo::Streams::Broadcasts
   end
 
   def broadcast_action_to(*streamables, action:, target: nil, targets: nil, attributes: {}, **rendering)
-    attributes.deep_symbolize_keys! if RUBY_VERSION < "3"
-
     broadcast_stream_to(*streamables, content: turbo_stream_action_tag(
       action, target: target, targets: targets, template: render_broadcast_action(rendering), **attributes)
     )

--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -22,12 +22,7 @@ module Turbo::Streams::ActionHelper
   #   message = Message.find(1)
   #   turbo_stream_action_tag "remove", target: [message, :special]
   #   # => <turbo-stream action="remove" target="special_message_1"></turbo-stream>
-  def turbo_stream_action_tag(action, attributes = {})
-    attributes.deep_symbolize_keys! if RUBY_VERSION < "3"
-
-    target = attributes.delete(:target)
-    targets = attributes.delete(:targets)
-    template = attributes.delete(:template)
+  def turbo_stream_action_tag(action, target: nil, targets: nil, template: nil, **attributes)
     template = action.to_sym.in?(%i[ remove refresh ]) ? "" : tag.template(template.to_s.html_safe)
 
     if target = convert_to_turbo_stream_dom_id(target)
@@ -44,7 +39,7 @@ module Turbo::Streams::ActionHelper
   #   turbo_stream_refresh_tag
   #   # => <turbo-stream action="refresh"></turbo-stream>
   def turbo_stream_refresh_tag(request_id: Turbo.current_request_id, **attributes)
-    turbo_stream_action_tag(:refresh, attributes.with_defaults({ "request-id": request_id }.compact))
+    turbo_stream_action_tag(:refresh, "request-id": request_id.presence, **attributes)
   end
 
   private

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -508,7 +508,7 @@ module Turbo::Broadcastable
       self.class.broadcast_target_default
     end
 
-    def extract_options_and_add_target(rendering, target: broadcast_target_default)
+    def extract_options_and_add_target(rendering = {}, target: broadcast_target_default)
       broadcast_rendering_with_defaults(rendering).tap do |options|
         options[:target] = target if !options.key?(:target) && !options.key?(:targets)
       end

--- a/app/models/turbo/streams/tag_builder.rb
+++ b/app/models/turbo/streams/tag_builder.rb
@@ -240,8 +240,8 @@ class Turbo::Streams::TagBuilder
   #
   #   turbo_stream.refresh request_id: "abc123"
   #   # => <turbo-stream action="refresh" request-id="abc123"></turbo-stream>
-  def refresh(**options)
-    turbo_stream_refresh_tag(**options)
+  def refresh(...)
+    turbo_stream_refresh_tag(...)
   end
 
   # Send an action of the type <tt>name</tt> to <tt>target</tt>. Options described in the concrete methods.

--- a/bug_report_template.rb
+++ b/bug_report_template.rb
@@ -6,7 +6,7 @@ gemfile(true) do
   gem "rails"
   gem "propshaft"
   gem "puma"
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
   gem "turbo-rails"
 
   gem "capybara"

--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -164,7 +164,7 @@ module Turbo
       ActiveSupport.on_load(:action_dispatch_system_test_case) do
         app.config.turbo.test_connect_after_actions.map do |method|
           class_eval <<~RUBY, __FILE__, __LINE__ + 1
-            def #{method}(*args, &block)                          # def visit(*args, &block)
+            def #{method}(...)                                    # def visit(...)
               super.tap { connect_turbo_cable_stream_sources }    #   super.tap { connect_turbo_cable_stream_sources }
             end                                                   # end
           RUBY

--- a/lib/turbo/system_test_helper.rb
+++ b/lib/turbo/system_test_helper.rb
@@ -51,8 +51,8 @@ module Turbo::SystemTestHelper
   #
   # In addition to the filters listed above, accepts any valid Capybara global
   # filter option.
-  def assert_turbo_cable_stream_source(*args, &block)
-    assert_selector(:turbo_cable_stream_source, *args, &block)
+  def assert_turbo_cable_stream_source(...)
+    assert_selector(:turbo_cable_stream_source, ...)
   end
 
   # Asserts that a `<turbo-cable-stream-source>` element is absent from the
@@ -75,8 +75,8 @@ module Turbo::SystemTestHelper
   #
   # In addition to the filters listed above, accepts any valid Capybara global
   # filter option.
-  def assert_no_turbo_cable_stream_source(*args, &block)
-    assert_no_selector(:turbo_cable_stream_source, *args, &block)
+  def assert_no_turbo_cable_stream_source(...)
+    assert_no_selector(:turbo_cable_stream_source, ...)
   end
 
   Capybara.add_selector :turbo_cable_stream_source do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,7 @@ require "rails/test_help"
 ActionCable.server.config.logger = Logger.new(STDOUT) if ENV["VERBOSE"]
 
 module ActionViewTestCaseExtensions
-  def render(*args, &block)
-    ApplicationController.renderer.render(*args, &block)
-  end
+  delegate :render, to: ApplicationController
 end
 
 class ActiveSupport::TestCase

--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/hotwired/turbo-rails"
   s.license  = "MIT"
 
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 3.1"
 
-  s.add_dependency "actionpack", ">= 6.0.0"
-  s.add_dependency "railties", ">= 6.0.0"
+  s.add_dependency "actionpack", ">= 7.1.0"
+  s.add_dependency "railties", ">= 7.1.0"
 
   s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
Related to https://github.com/hotwired/turbo-rails/issues/681
Follow-up to https://github.com/hotwired/turbo-rails/pull/682

Commit to requiring `ruby@3.1`
    
Remove `ruby@2.6`, `ruby@2.7`, `ruby@3.0`, `rails@6.1`, and `rails@7.0` from the CI matrix, along with any `RUBY_VERSION < "3"` conditionals.
    
The implementation changes include replace older syntaxes with newer variants. For example, utilize `...` in place of `*args, &block`, rely on `**`-ing attribute `Hash` arguments, etc.