### PR TITLE
Keep flash in Turbo Frame requests

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -23,6 +23,7 @@ module Turbo::Frames::FrameRequest
   included do
     layout -> { "turbo_rails/frame" if turbo_frame_request? }
     etag { :frame if turbo_frame_request? }
+    before_action { flash.keep if turbo_frame_request? }
 
     helper_method :turbo_frame_request?, :turbo_frame_request_id
   end

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -16,7 +16,7 @@ class MessagesController < ApplicationController
 
   def create
     respond_to do |format|
-      format.html { redirect_to message_url(id: 1) }
+      format.html { redirect_to message_url(id: 1), notice: "Message was successfully created." }
       format.turbo_stream { render turbo_stream: turbo_stream.append(:messages, "message_1"), status: :created }
     end
   end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <body class="<%= "turbo-native" if turbo_native_app? %>">
+    <%= flash[:notice] %>
     <%= yield %>
   </body>
 </html>

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -35,6 +35,22 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal etag_with_frame, etag_without_frame
   end
 
+  test "frame requests keep the flash" do
+    message = Message.create!
+
+    post messages_path
+    assert_equal @request.flash[:notice], 'Message was successfully created.'
+
+    get messages_path, headers: { "Turbo-Frame" => "true" }
+    assert_equal @request.flash[:notice], 'Message was successfully created.'
+
+    get messages_path
+    assert_equal @request.flash[:notice], 'Message was successfully created.'
+
+    get messages_path
+    assert_nil @request.flash[:notice]
+  end
+
   test "turbo_frame_request_id returns the Turbo-Frame header value" do
     turbo_frame_request_id = "test_frame_id"
 


### PR DESCRIPTION
A POST request can set the flash and return a redirect response. If a Turbo-Frame request that gets made before the redirect location gets called, the flash gets discared by the Turbo-Frame request.

By making sure a Turbo-Frame request keeps the flash, we can avoid this problem.