### PR TITLE
update CI matrix for Rails 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ "7.0", "7.1", "7.2", "8.0" ]
+        rails: [ "7.1", "7.2", "8.0" ]
         ruby: [ "3.1", "3.2", "3.3" ]
         allow-fail: [ false ]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ "6.1", "7.0", "7.1", "7.2" ]
-        ruby: [ "2.7", "3.0", "3.1", "3.2", "3.3" ]
+        rails: [ "7.0", "7.1", "7.2", "8.0" ]
+        ruby: [ "3.1", "3.2", "3.3" ]
         allow-fail: [ false ]
         include:
-          - { ruby: "2.6",  rails: "6.1" }
           - { ruby: "3.3",  rails: "main", allow-fail: true }
-          - { ruby: "3.2",  rails: "main", allow-fail: true }
           - { ruby: "head", rails: "main", allow-fail: true }
-        exclude:
-          - { ruby: "2.7", rails: "7.2" }
-          - { ruby: "3.0", rails: "7.2" }
 
     env:
       FERRUM_PROCESS_TIMEOUT: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - { ruby: "3.3",  rails: "main", allow-fail: true }
           - { ruby: "head", rails: "main", allow-fail: true }
         exclude:
-          - { ruby: "3.2", rails: "8.0" }
+          - { ruby: "3.1", rails: "8.0" }
 
     env:
       FERRUM_PROCESS_TIMEOUT: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         include:
           - { ruby: "3.3",  rails: "main", allow-fail: true }
           - { ruby: "head", rails: "main", allow-fail: true }
+        exclude:
+          - { ruby: "3.2", rails: "8.0" }
 
     env:
       FERRUM_PROCESS_TIMEOUT: 25

--- a/Gemfile
+++ b/Gemfile
@@ -36,5 +36,5 @@ group :test do
   gem 'capybara'
   gem 'rexml'
   gem 'cuprite', '~> 0.9', require: 'capybara/cuprite'
-  gem 'sqlite3', '1.5'
+  gem 'sqlite3'
 end

--- a/bug_report_template.rb
+++ b/bug_report_template.rb
@@ -6,7 +6,7 @@ gemfile(true) do
   gem "rails"
   gem "propshaft"
   gem "puma"
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
   gem "turbo-rails"
 
   gem "capybara"

--- a/turbo-rails.gemspec
+++ b/turbo-rails.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/hotwired/turbo-rails"
   s.license  = "MIT"
 
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 3.1.0"
 
-  s.add_dependency "actionpack", ">= 6.0.0"
-  s.add_dependency "railties", ">= 6.0.0"
+  s.add_dependency "actionpack", ">= 7.0.0"
+  s.add_dependency "railties", ">= 7.0.0"
 
   s.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
- Removes EOL Ruby 2.7, 3.0 
- Removes EOL Rails 6.1, 7.0
- Adds Rails 8
- update sqlite dependency 