### PR TITLE
add test missing assertion

### DIFF
--- a/test/system/form_submissions_test.rb
+++ b/test/system/form_submissions_test.rb
@@ -5,8 +5,10 @@ class FormSubmissionsTest < ApplicationSystemTestCase
     article = Article.create! body: "My article"
 
     visit edit_article_path(article.id)
-
     click_on "articles#index"
+
+    assert_text "Articles"
+    assert_text "My article"
   end
 
   test "form submission method is encoded as _method" do


### PR DESCRIPTION
One test didn't have any assertions and we could see this warning when running tests

```
Test is missing assertions: `test_form_submission_[method=get]`
```

This PR adds simple text assertion to silence the warning 