### PR TITLE
Fix unwanted model retention when using class methods from `Turbo::Broadcastable` with locals

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -518,7 +518,7 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        o[:locals] = (o[:locals] || {}).reverse_merge!(model_name.element.to_sym => self).compact
+        o[:locals] = (o[:locals] || {}).reverse_merge(model_name.element.to_sym => self).compact
 
         if o[:html] || o[:partial]
           return o

--- a/test/dummy/app/models/comment.rb
+++ b/test/dummy/app/models/comment.rb
@@ -5,5 +5,6 @@ class Comment < ApplicationRecord
 
   broadcasts_to ->(comment) { [comment.article, :comments] },
     target: ->(comment) { "article_#{comment.article_id}_comments" },
-    partial: "comments/different_comment"
+    partial: "comments/different_comment",
+    locals: { highlight: true }
 end

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -441,6 +441,23 @@ class Turbo::BroadcastableCommentTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "creating a second comment while using locals broadcasts the second comment" do
+    stream = "#{@article.to_gid_param}:comments"
+    target = "article_#{@article.id}_comments"
+
+    assert_broadcast_on stream, turbo_stream_action_tag("append", target: target, template: %(<p class="different">comment</p>\n)) do
+      perform_enqueued_jobs do
+        @article.comments.create!(body: "comment")
+      end
+    end
+
+    assert_broadcast_on stream, turbo_stream_action_tag("append", target: target, template: %(<p class="different">another comment</p>\n)) do
+      perform_enqueued_jobs do
+        @article.comments.create!(body: "another comment")
+      end
+    end
+  end
+
   test "updating a comment broadcasts" do
     comment = @article.comments.create!(body: "random")
     stream = "#{@article.to_gid_param}:comments"


### PR DESCRIPTION
Consider the following model:

```ruby
class MyModel < ApplicationRecord
  broadcasts locals: { something_static: true }
end
```

When broadcasting for the first time without this fix, Broadcastable does something like:

```ruby
{ something_static }.reverse_merge!(my_model: #<MyModel: id=1>)
```

On the second broadcast for another model instance, the reverse merge will be a no-op, because the first model is already in the Hash!

Switching to a non-destructive `reverse_merge` resolves the issue.