### PR TITLE
Join array elements with underscore in turbo_stream_action_tag target

### DIFF
--- a/app/helpers/turbo/streams/action_helper.rb
+++ b/app/helpers/turbo/streams/action_helper.rb
@@ -52,6 +52,8 @@ module Turbo::Streams::ActionHelper
       target_array = Array.wrap(target)
       if target_array.any? { |value| value.respond_to?(:to_key) }
         "#{"#" if include_selector}#{ActionView::RecordIdentifier.dom_id(*target_array)}"
+      elsif target.present?
+        target_array.join('_')
       else
         target
       end

--- a/test/streams/action_helper_test.rb
+++ b/test/streams/action_helper_test.rb
@@ -108,4 +108,16 @@ class Turbo::ActionHelperTest < ActionCable::Channel::TestCase
 
     assert_equal "<turbo-stream request-id=\"123\" action=\"refresh\"></turbo-stream>", action
   end
+
+  test "properly builds is for non-record array target" do
+    stream = "<turbo-stream action=\"append\" target=\"foo_1_2\"><template></template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", target: ['foo', 1, 2])
+  end
+
+  test "properly builds is for non-record array targets" do
+    stream = "<turbo-stream action=\"append\" targets=\"foo_1_2\"><template></template></turbo-stream>"
+
+    assert_equal stream, turbo_stream_action_tag("append", targets: ['foo', 1, 2])
+  end
 end


### PR DESCRIPTION
`turbo_frame_tag` joins ids with underscore, to keep this consistent I think it should be done similarly by `turbo_stream_action_tag` 