### PR TITLE
Remove compact call on locals in broadcast_rendering_with_defaults

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -518,7 +518,7 @@ module Turbo::Broadcastable
       options.tap do |o|
         # Add the current instance into the locals with the element name (which is the un-namespaced name)
         # as the key. This parallels how the ActionView::ObjectRenderer would create a local variable.
-        o[:locals] = (o[:locals] || {}).reverse_merge(model_name.element.to_sym => self).compact
+        o[:locals] = (o[:locals] || {}).reverse_merge(model_name.element.to_sym => self)
 
         if o[:html] || o[:partial]
           return o


### PR DESCRIPTION
This PR removes the compact call from the locals hash in the broadcast_rendering_with_defaults method. Previously, compact might have caused unintended removal of keys associated with nil values.

This change should match how partials usually behave in ActionView