### PR TITLE
Turbo::Streams::Broadcasts#render_format support for controller_klass option

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -108,7 +108,7 @@ module Turbo::Streams::Broadcasts
 
   private
     def render_format(format, **rendering)
-      ApplicationController.render(formats: [ format ], **rendering)
+      (rendering.delete(:controller_klass) || ApplicationController).render(formats: [ format ], **rendering)
     end
 
     def render_broadcast_action(rendering)


### PR DESCRIPTION
Rails by default includes all view helpers in a view's context when rendering it, but provides `action_controller.include_all_helpers` option ([docs](https://api.rubyonrails.org/v8.0.0/classes/ActionController/Helpers.html)) to disable such behaviour:
```
config.action_controller.include_all_helpers = false
```

When broadcasting to streams, `Turbo::Streams::Broadcasts#render_format` uses `ApplicationController` to call `render`.
Combined with disabled option above, for example a `broadcast_render_to` call fails when template uses some helpers not included by Rails automatically.

This patch introduces `controller_klass` option for `Turbo::Streams::Broadcasts#render_format` and methods built on top of it to pass a subclass of `ActionController::Base` which includes all the needed helpers and possibly other behaviour needed to successfully render the required template:

```
broadcast_render_to(
      'items',
      template: 'items/update',
      format: ['turbo_stream'],
      locals: { item: self },
      controller: V2::VerySpecificItemController
    )
```