### PR TITLE
Fix stream_name calculation inside of thread

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -69,7 +69,7 @@ module Turbo::Streams::Broadcasts
 
   def broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id, **opts)
     stream_name = stream_name_from(streamables)
-    
+
     refresh_debouncer_for(stream_name, request_id: request_id).debounce do
       Turbo::Streams::BroadcastStreamJob.perform_later stream_name, content: turbo_stream_refresh_tag(request_id: request_id, **opts).to_str # Sidekiq requires job arguments to be valid JSON types, such as String
     end

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -70,7 +70,7 @@ module Turbo::Streams::Broadcasts
   def broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id, **opts)
     stream_name = stream_name_from(streamables)
 
-    refresh_debouncer_for(stream_name, request_id: request_id).debounce do
+    refresh_debouncer_for(*streamables, request_id: request_id).debounce do
       Turbo::Streams::BroadcastStreamJob.perform_later stream_name, content: turbo_stream_refresh_tag(request_id: request_id, **opts).to_str # Sidekiq requires job arguments to be valid JSON types, such as String
     end
   end

--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -68,8 +68,10 @@ module Turbo::Streams::Broadcasts
   end
 
   def broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id, **opts)
-    refresh_debouncer_for(*streamables, request_id: request_id).debounce do
-      Turbo::Streams::BroadcastStreamJob.perform_later stream_name_from(streamables), content: turbo_stream_refresh_tag(request_id: request_id, **opts).to_str # Sidekiq requires job arguments to be valid JSON types, such as String
+    stream_name = stream_name_from(streamables)
+    
+    refresh_debouncer_for(stream_name, request_id: request_id).debounce do
+      Turbo::Streams::BroadcastStreamJob.perform_later stream_name, content: turbo_stream_refresh_tag(request_id: request_id, **opts).to_str # Sidekiq requires job arguments to be valid JSON types, such as String
     end
   end
 


### PR DESCRIPTION
Calculating the stream_name from within the `ThreadDebouncer` was leading to incorrect stream channel names in my setup where the `global_id` includes the Tennant id. It's a multi-tenant application and the current database name forms part of the `global_id`. Within the `ThreadDebouncer` it would seem to fixate on a particular database connection rather than the connection used by the current request.

Simply calculating the `stream_name` before invoking the `ThreadDebouncer` fixed the issue.

I don't see the need for additional tests unless you wanted to test my failure scenario but I'm not quite sure how to do that.