### PR TITLE
Accept symbol, proc, and nil arguments for broadcasts_refreshes

### DIFF
--- a/test/dummy/app/models/board.rb
+++ b/test/dummy/app/models/board.rb
@@ -1,3 +1,6 @@
 class Board < ApplicationRecord
   broadcasts_refreshes
+  broadcasts_refreshes nil
+  broadcasts_refreshes :columns; def columns = [self, :columns]
+  broadcasts_refreshes ->(board) { [board, :cards] }
 end


### PR DESCRIPTION
Currently, `broadcasts_refreshes` only accepts values in the form of a string or nil, where explicitly passing nil bypasses broadcasting but still triggers the `after_create_commit` callback.

This change allows you to pass a symbol (method name to call) or a proc to evaluate to `broadcasts_refreshes` to produce a stream name dynamically at the instance level `after_create_commit`.

This allows us to, for example, specify a parent (Board) to broadcast refreshes to on `create`, while broadcasting to itself (Column) on `update` and `destroy`:

```rb
class Column < ApplicationRecord
  belongs_to :board
  broadcasts_refreshes :board
end
```

Listen for new `Column` creations for `@board`:

```erb
<%= turbo_stream_from @board %> 
```

Listen for updates and deletion of existing `@column`: 

```erb
<%= turbo_stream_from @column %> 
```

This changes also disables the entire `after_create_commit` hook if `nil` is passed in explicitly, rather than allowing it to run without broadcasting anything.