### PR TITLE
Add `rails@8.1` to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ "7.1", "7.2", "8.0" ]
+        rails: [ "7.2", "8.0", "8.1" ]
         ruby: [ "3.1", "3.4" ]
         allow-fail: [ false ]
         include:
           - { ruby: "3.4",  rails: "main", allow-fail: true }
         exclude:
           - { ruby: "3.1", rails: "8.0" }
+          - { ruby: "3.1", rails: "8.1" }
 
     env:
       FERRUM_PROCESS_TIMEOUT: 25


### PR DESCRIPTION
[Rails 8.1 has been released][rails@8.1], so expand the CI matrix of exercised versions to include it.

Since [Rails 7.1 has entered its end-of-life][eol], remove it from the CI support matrix.

[rails@8.1]: https://rubyonrails.org/2025/10/22/rails-8-1
[eol]: https://rubyonrails.org/2025/10/29/new-rails-releases-and-end-of-support-announcement