### PR TITLE
TurboStreamEncoder: redefine `accept_header` method

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -142,10 +142,11 @@ module Turbo
     initializer "turbo.integration_test_request_encoding" do
       ActiveSupport.on_load(:action_dispatch_integration_test) do
         # Support `as: :turbo_stream`. Public `register_encoder` API is a little too strict.
+        require "active_support/core_ext/module/redefine_method"
         class ActionDispatch::RequestEncoder
           class TurboStreamEncoder < IdentityEncoder
             header = [ Mime[:turbo_stream], Mime[:html] ].join(",")
-            define_method(:accept_header) { header }
+            redefine_method(:accept_header) { header }
           end
 
           @encoders[:turbo_stream] = TurboStreamEncoder.new


### PR DESCRIPTION
Since the `action_dispatch_integration_test` hook is invoked for each integration test, the whole `TurboStreamEncoder` is (re)defined many times.

Ideally, I think, `@encoders[:turbo_stream]` should be set once, but since `RequestEncoder` does not expose straightforward API to check if an encoder is registered, we'd have to use something like

```ruby
ActionDispatch::RequestEncoder::IdentityEncoder === ActionDispatch::RequestEncoder.encoder(:turbo_stream)
```

which is not handy.

NB: requiring AS is not necessary -- we can use the self-alias trick instead