### PR TITLE
[fix #762] Forward broadcast_refresh_to options

### DIFF
--- a/app/channels/turbo/streams/broadcasts.rb
+++ b/app/channels/turbo/streams/broadcasts.rb
@@ -33,8 +33,8 @@ module Turbo::Streams::Broadcasts
     broadcast_action_to(*streamables, action: :prepend, **opts)
   end
 
-  def broadcast_refresh_to(*streamables, **opts)
-    broadcast_stream_to(*streamables, content: turbo_stream_refresh_tag)
+  def broadcast_refresh_to(*streamables, **attributes)
+    broadcast_stream_to(*streamables, content: turbo_stream_refresh_tag(**attributes))
   end
 
   def broadcast_action_to(*streamables, action:, target: nil, targets: nil, attributes: {}, **rendering)

--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -378,8 +378,8 @@ module Turbo::Broadcastable
   #
   #   # Sends <turbo-stream action="refresh"></turbo-stream> to the stream named "identity:2:clearances"
   #   clearance.broadcast_refresh_to examiner.identity, :clearances
-  def broadcast_refresh_to(*streamables)
-    Turbo::StreamsChannel.broadcast_refresh_to(*streamables) unless suppressed_turbo_broadcasts?
+  def broadcast_refresh_to(*streamables, **attributes)
+    Turbo::StreamsChannel.broadcast_refresh_to(*streamables, **attributes) unless suppressed_turbo_broadcasts?
   end
 
   #  Same as <tt>#broadcast_refresh_to</tt>, but the designated stream is automatically set to the current model.
@@ -442,8 +442,8 @@ module Turbo::Broadcastable
   end
 
   #  Same as <tt>broadcast_refresh_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.
-  def broadcast_refresh_later_to(*streamables)
-    Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id) unless suppressed_turbo_broadcasts?
+  def broadcast_refresh_later_to(*streamables, **attributes)
+    Turbo::StreamsChannel.broadcast_refresh_later_to(*streamables, request_id: Turbo.current_request_id, **attributes) unless suppressed_turbo_broadcasts?
   end
 
   #  Same as <tt>#broadcast_refresh_later_to</tt>, but the designated stream is automatically set to the current model.

--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -78,6 +78,22 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting refresh now" do
+    Turbo.with_request_id("123") do
+      assert_broadcast_on "stream", turbo_stream_refresh_tag(request_id: nil) do
+        Turbo::StreamsChannel.broadcast_refresh_to "stream", request_id: nil
+      end
+
+      assert_broadcast_on "stream", turbo_stream_refresh_tag(request_id: "123") do
+        Turbo::StreamsChannel.broadcast_refresh_to "stream"
+      end
+      
+      assert_broadcast_on "stream", turbo_stream_refresh_tag(request_id: "456", refresh: "morph") do
+        Turbo::StreamsChannel.broadcast_refresh_to "stream", request_id: "456", refresh: "morph"
+      end
+    end
+  end
+
   test "broadcasting action now" do
     options = { partial: "messages/message", locals: { message: "hello!" } }
 


### PR DESCRIPTION
The previously ignored options of `broadcast_refresh_to` are now forwarded to `turbo_stream_refresh_tag`.

This PR resolves #762 and is in support of https://github.com/hotwired/turbo/pull/1208.