### PR TITLE
Remove legacy workaround for Rails < 7

### DIFF
--- a/lib/turbo/engine.rb
+++ b/lib/turbo/engine.rb
@@ -18,43 +18,17 @@ module Turbo
 
     # If the parent application does not use Active Job, app/jobs cannot
     # be eager loaded, because it references the ActiveJob constant.
-    #
-    # When turbo-rails depends on Rails 7 or above, the entire block can be
-    # reduced to
-    #
-    #   unless defined?(ActiveJob)
-    #     Rails.autoloaders.once.do_not_eager_load("#{root}/app/jobs")
-    #   end
-    #
     initializer "turbo.no_active_job", before: :set_eager_load_paths do
       unless defined?(ActiveJob)
-        if Rails.autoloaders.zeitwerk_enabled?
-          Rails.autoloaders.once.do_not_eager_load("#{root}/app/jobs")
-        else
-          # This else branch only runs in Rails 6.x + classic mode.
-          config.eager_load_paths.delete("#{root}/app/jobs")
-        end
+        Rails.autoloaders.once.do_not_eager_load("#{root}/app/jobs")
       end
     end
 
     # If the parent application does not use Action Cable, app/channels cannot
     # be eager loaded, because it references the ActionCable constant.
-    #
-    # When turbo-rails depends on Rails 7 or above, the entire block can be
-    # reduced to
-    #
-    #   unless defined?(ActionCable)
-    #     Rails.autoloaders.once.do_not_eager_load("#{root}/app/channels")
-    #   end
-    #
     initializer "turbo.no_action_cable", before: :set_eager_load_paths do
       unless defined?(ActionCable)
-        if Rails.autoloaders.zeitwerk_enabled?
-          Rails.autoloaders.once.do_not_eager_load("#{root}/app/channels")
-        else
-          # This else branch only runs in Rails 6.x + classic mode.
-          config.eager_load_paths.delete("#{root}/app/channels")
-        end
+        Rails.autoloaders.once.do_not_eager_load("#{root}/app/channels")
       end
     end
 


### PR DESCRIPTION
As of 3fcec46, turbo-rails depends on rails >= 7.1.0.