### PR TITLE
Fix debouncer tests to wait on correct debouncer

### DIFF
--- a/test/streams/streams_channel_test.rb
+++ b/test/streams/streams_channel_test.rb
@@ -87,7 +87,7 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
       assert_broadcast_on "stream", turbo_stream_refresh_tag(request_id: "123") do
         Turbo::StreamsChannel.broadcast_refresh_to "stream"
       end
-      
+
       assert_broadcast_on "stream", turbo_stream_refresh_tag(request_id: "456", refresh: "morph") do
         Turbo::StreamsChannel.broadcast_refresh_to "stream", request_id: "456", refresh: "morph"
       end
@@ -229,8 +229,10 @@ class Turbo::StreamsChannelTest < ActionCable::Channel::TestCase
               Turbo.current_request_id = "456"
               3.times { Turbo::StreamsChannel.broadcast_refresh_later_to "stream" }
 
-              Turbo::StreamsChannel.refresh_debouncer_for("stream", request_id: "123").wait
-              Turbo::StreamsChannel.refresh_debouncer_for("stream", request_id: "456").wait
+              debouncer_123 = Turbo::StreamsChannel.refresh_debouncer_for("stream", request_id: "123")
+              debouncer_456 = Turbo::StreamsChannel.refresh_debouncer_for("stream", request_id: "456")
+              debouncer_123.wait
+              debouncer_456.wait
             end
           end
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,7 @@ class ActiveSupport::TestCase
     sleep Turbo::Debouncer::DEFAULT_DELAY + 0.2
 
     turbo_keys = Thread.current.keys.select { |k| k.to_s.start_with?("turbo-") }
-    assert_empty turbo_keys, "Thread-locals were not cleaned up" if RUBY_VERSION >= "3.3"
+    assert_empty turbo_keys, "Thread-locals were not cleaned up"
   end
 end
 


### PR DESCRIPTION
The wait for the debouncer_123 debouncer meant that calling refresh_debouncer_for with request_id: "456" could create a new debouncer rather than returning the existing one.

See https://github.com/hotwired/turbo-rails/pull/764 (cc @seanpdoyle)