### PR TITLE
Restrict tests to `minitest < 6`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,6 @@ group :test do
   gem 'capybara'
   gem 'rexml'
   gem 'cuprite', '~> 0.9', require: 'capybara/cuprite'
+  gem 'minitest', '< 6'
   gem 'sqlite3'
 end

--- a/bug_report_template.rb
+++ b/bug_report_template.rb
@@ -11,6 +11,7 @@ gemfile(true) do
 
   gem "capybara"
   gem "cuprite", require: "capybara/cuprite"
+  gem "minitest", "< 6"
 end
 
 ENV["DATABASE_URL"] = "sqlite3::memory:"


### PR DESCRIPTION
There are currently [CI Failures][] related to the latest version of
`minitest`:

```
/opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/railties-8.1.1/lib/rails/test_unit/line_filtering.rb:7:in `run': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
```

Until the latest Rails releases on stable branches adopt support for
`minitest > 6`, fix the version in the `bug_report_template.rb` inline
Gemfile.

The unbounded minitest version is also negatively impacting the rest of
the [test suite][]:

```
<internal:/opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- minitest/mock (LoadError)
```

Include a `< 6` version constraint in the `Gemfile` as well.

[CI Failures]: https://github.com/hotwired/turbo-rails/actions/runs/20479960692/job/58886338414?pr=736#step:4:200
[test suite]: https://github.com/hotwired/turbo-rails/actions/runs/20492294729/job/58886518537?pr=774#step:6:19

