### PR TITLE
Introduce BaseJob for all streaming jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ This gem provides a `turbo_stream_from` helper to create a turbo stream.
 <%# Rest of show here %>
 ```
 
+To configure Active Job priority for all Turbo Streams job, you can set in the initializer:
+
+```ruby
+# config/initializers/turbo.rb
+Rails.application.config.after_initialize do
+  Turbo::Streams::BaseJob.priority = 100
+end
+```
+
 ### Testing Turbo Stream Broadcasts
 
 Receiving server-generated Turbo Broadcasts requires a connected Web Socket.

--- a/app/jobs/turbo/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo/streams/action_broadcast_job.rb
@@ -1,7 +1,5 @@
 # The job that powers all the <tt>broadcast_$action_later</tt> broadcasts available in <tt>Turbo::Streams::Broadcasts</tt>.
-class Turbo::Streams::ActionBroadcastJob < ActiveJob::Base
-  discard_on ActiveJob::DeserializationError
-  
+class Turbo::Streams::ActionBroadcastJob < Turbo::Streams::BaseJob
   def perform(stream, action:, target:, attributes: {}, **rendering)
     Turbo::StreamsChannel.broadcast_action_to stream, action: action, target: target, attributes: attributes, **rendering
   end

--- a/app/jobs/turbo/streams/base_job.rb
+++ b/app/jobs/turbo/streams/base_job.rb
@@ -1,0 +1,3 @@
+class Turbo::Streams::BaseJob < ActiveJob::Base
+  discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/turbo/streams/broadcast_job.rb
+++ b/app/jobs/turbo/streams/broadcast_job.rb
@@ -1,8 +1,6 @@
 # The job that powers the <tt>broadcast_render_later_to</tt> available in <tt>Turbo::Streams::Broadcasts</tt> for rendering
 # turbo stream templates.
-class Turbo::Streams::BroadcastJob < ActiveJob::Base
-  discard_on ActiveJob::DeserializationError
-
+class Turbo::Streams::BroadcastJob < Turbo::Streams::BaseJob
   def perform(stream, **rendering)
     Turbo::StreamsChannel.broadcast_render_to stream, **rendering
   end

--- a/app/jobs/turbo/streams/broadcast_stream_job.rb
+++ b/app/jobs/turbo/streams/broadcast_stream_job.rb
@@ -1,6 +1,4 @@
-class Turbo::Streams::BroadcastStreamJob < ActiveJob::Base
-  discard_on ActiveJob::DeserializationError
-
+class Turbo::Streams::BroadcastStreamJob < Turbo::Streams::BaseJob
   def perform(stream, content:)
     Turbo::StreamsChannel.broadcast_stream_to(stream, content: content)
   end


### PR DESCRIPTION
This way it is easy to configure all decendant jobs

```ruby
Rails.application.config.after_initialize do
  Turbo::Streams::BaseJob.priority = 100
end
```