### PR TITLE
Use a method-based frame layout to avoid _layout_from_proc redefinition warning

### DIFF
--- a/app/controllers/turbo/frames/frame_request.rb
+++ b/app/controllers/turbo/frames/frame_request.rb
@@ -21,13 +21,24 @@ module Turbo::Frames::FrameRequest
   extend ActiveSupport::Concern
 
   included do
-    layout -> { "turbo_rails/frame" if turbo_frame_request? }
+    layout :turbo_frame_request_layout
     etag { :frame if turbo_frame_request? }
 
     helper_method :turbo_frame_request?, :turbo_frame_request_id
   end
 
   private
+    # Use a method-based (Symbol) layout rather than a Proc. A Proc-based layout
+    # makes Rails define a private +_layout_from_proc+ method on every including
+    # controller, which is then redefined whenever a controller in the chain sets
+    # its own layout — emitting a "method redefined; discarding old
+    # _layout_from_proc" warning under Ruby's verbose mode (on by default in Ruby
+    # 4.0). A Symbol layout resolves the same way (frame layout on frame requests,
+    # default layout otherwise) without defining that method. See issue #783.
+    def turbo_frame_request_layout
+      "turbo_rails/frame" if turbo_frame_request?
+    end
+
     def turbo_frame_request?
       turbo_frame_request_id.present?
     end

--- a/test/frames/frame_request_controller_test.rb
+++ b/test/frames/frame_request_controller_test.rb
@@ -57,6 +57,22 @@ class Turbo::FrameRequestControllerTest < ActionDispatch::IntegrationTest
     end
 end
 
+class Turbo::FrameRequestLayoutTest < ActiveSupport::TestCase
+  # Regression test for #783. The frame layout must be installed as a method
+  # (Symbol) rather than a Proc. A Proc-based layout makes Rails define a private
+  # `_layout_from_proc` on every controller that includes the module, which is
+  # then redefined whenever a controller in the chain sets its own layout —
+  # emitting a "method redefined; discarding old _layout_from_proc" warning under
+  # verbose mode (on by default in Ruby 4.0).
+  test "frame layout does not define _layout_from_proc on including controllers" do
+    controller = Class.new(ActionController::Base)
+
+    assert_not controller.private_instance_methods.include?(:_layout_from_proc),
+      "Turbo's frame layout should be a Symbol-based layout so that Rails does " \
+      "not define (and later redefine, with a warning) _layout_from_proc. See #783."
+  end
+end
+
 class Turbo::FrameRequestViewTest < ActionView::TestCase
   test "supports rendering context without request object" do
     @rendered = ApplicationController.render(template: "trays/show")


### PR DESCRIPTION
## What

`Turbo::Frames::FrameRequest` installs its frame layout with a Proc:

```ruby
layout -> { "turbo_rails/frame" if turbo_frame_request? }
```

A Proc layout makes Rails' `_write_layout_method` define a private `_layout_from_proc` on every controller that includes the module (it re-runs on each subclass via the `inherited` hook). That `define_method` isn't silenced, so when a controller in the chain also sets its own layout the method gets redefined and Ruby warns:

```
actionview/lib/action_view/layouts.rb:311: warning: method redefined; discarding old _layout_from_proc
turbo-rails/app/controllers/turbo/frames/frame_request.rb:24: warning: previous definition of _layout_from_proc was here
```

It's a verbose-mode warning today, but verbose is **on by default in Ruby 4.0**, so it now surfaces for every app on the upgrade path. Reported in #783.

## Fix

Use a Symbol (method) layout instead of a Proc:

```ruby
layout :turbo_frame_request_layout

# ...
def turbo_frame_request_layout
  "turbo_rails/frame" if turbo_frame_request?
end
```

This resolves identically. In `_write_layout_method`, the Symbol and Proc branches both return the layout name when the value is truthy and fall through to the same default-layout lookup when it's `nil` — but the Symbol branch never defines `_layout_from_proc`, so the warning is gone with no behavior change.

## Test

Adds a regression test asserting the frame layout no longer installs `_layout_from_proc` on including controllers. It fails on the old Proc-based layout and passes with this change. The existing frame-layout behavior tests (minimal layout on frame requests, `head` content, override, unique etag) continue to pass.

Fixes #783