### PR TITLE
Forward attributes to broadcast_refresh_to and broadcast_refresh_later_to

### DIFF
--- a/app/models/concerns/turbo/broadcastable.rb
+++ b/app/models/concerns/turbo/broadcastable.rb
@@ -383,8 +383,8 @@ module Turbo::Broadcastable
   end
 
   #  Same as <tt>#broadcast_refresh_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_refresh
-    broadcast_refresh_to self
+  def broadcast_refresh(**attributes)
+    broadcast_refresh_to self, **attributes
   end
 
   # Broadcast a named <tt>action</tt>, allowing for dynamic dispatch, instead of using the concrete action methods. Examples:
@@ -447,8 +447,8 @@ module Turbo::Broadcastable
   end
 
   #  Same as <tt>#broadcast_refresh_later_to</tt>, but the designated stream is automatically set to the current model.
-  def broadcast_refresh_later
-    broadcast_refresh_later_to self
+  def broadcast_refresh_later(**attributes)
+    broadcast_refresh_later_to self, **attributes
   end
 
   # Same as <tt>broadcast_action_to</tt> but run asynchronously via a <tt>Turbo::Streams::BroadcastJob</tt>.

--- a/test/streams/broadcastable_test.rb
+++ b/test/streams/broadcastable_test.rb
@@ -151,6 +151,12 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "broadcasting refresh now forwards attributes" do
+    assert_broadcast_on @message.to_gid_param, turbo_stream_refresh_tag(refresh: "morph") do
+      @message.broadcast_refresh refresh: "morph"
+    end
+  end
+
   test "broadcasting refresh later is debounced" do
     with_production_debouncer do
       assert_broadcast_on @message.to_gid_param, turbo_stream_refresh_tag do
@@ -162,6 +168,17 @@ class Turbo::BroadcastableTest < ActionCable::Channel::TestCase
               Turbo::StreamsChannel.refresh_debouncer_for(@message).wait
             end
           end
+        end
+      end
+    end
+  end
+
+  test "broadcasting refresh later forwards attributes" do
+    with_production_debouncer do
+      assert_broadcast_on @message.to_gid_param, turbo_stream_refresh_tag(refresh: "morph") do
+        perform_enqueued_jobs do
+          @message.broadcast_refresh_later refresh: "morph"
+          Turbo::StreamsChannel.refresh_debouncer_for(@message).wait
         end
       end
     end


### PR DESCRIPTION
#763 passes attributes from broadcast_refresh_to and broadcast_refresh_later_to to turbo_stream_refresh_tag but the model helpers which delegate to them (broadcast_refresh and broadcast_refresh_later) take no arguments.

The other broadcast methods (broadcast_replace, broadcast_append and so on) all accept attributes, so this  change brings the refresh variants in line.